### PR TITLE
feat!: rename module to go-sdk-contrib and replace golang-sdk module with go-sdk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      GOPATH: /home/runner/work/open-feature/golang-sdk-contrib
-      GOBIN: /home/runner/work/open-feature/golang-sdk-contrib/bin
+      GOPATH: /home/runner/work/open-feature/go-sdk-contrib
+      GOBIN: /home/runner/work/open-feature/go-sdk-contrib/bin
     steps:
       - name: Install Go
         uses: actions/setup-go@v3

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ lint:
 
 new-provider: 
 	mkdir ./providers/$(PROVIDER)
-	cd ./providers/$(PROVIDER) && go mod init github.com/open-feature/golang-sdk-contrib/providers/$(PROVIDER) && touch README.md
+	cd ./providers/$(PROVIDER) && go mod init github.com/open-feature/go-sdk-contrib/providers/$(PROVIDER) && touch README.md
 
 new-hook: 
 	mkdir ./hooks/$(HOOK)
-	cd ./hooks/$(HOOK) && go mod init github.com/open-feature/golang-sdk-contrib/hooks/$(HOOK) && touch README.md
+	cd ./hooks/$(HOOK) && go mod init github.com/open-feature/go-sdk-contrib/hooks/$(HOOK) && touch README.md

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Experimental](https://img.shields.io/badge/experimental-breaking%20changes%20allowed-yellow)
 ![Alpha](https://img.shields.io/badge/alpha-release-red)
 
-This repository is intended for OpenFeature contributions which are not included in the [OpenFeature SDK](https://github.com/open-feature/golang-sdk).
+This repository is intended for OpenFeature contributions which are not included in the [OpenFeature SDK](https://github.com/open-feature/go-sdk).
 
 The project includes:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenFeature Golang Contributions
+# OpenFeature Go Contributions
 
 ![Experimental](https://img.shields.io/badge/experimental-breaking%20changes%20allowed-yellow)
 ![Alpha](https://img.shields.io/badge/alpha-release-red)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,4 +1,4 @@
-# OpenFeature Golang Hooks
+# OpenFeature Go Hooks
 
 Hooks are a mechanism whereby application developers can add arbitrary behavior to flag evaluation. They operate similarly to middleware in many web frameworks. Please see the [spec](https://github.com/open-feature/spec/blob/main/specification/flag-evaluation/hooks.md) for more details.
 

--- a/hooks/validator/README.md
+++ b/hooks/validator/README.md
@@ -13,7 +13,7 @@ There are, however, [ready to be used validators](#validators) that conform to t
 
 ## Setup
 
-Import the [OpenFeature SDK](https://github.com/open-feature/golang-sdk) and the validator.
+Import the [OpenFeature SDK](https://github.com/open-feature/go-sdk) and the validator.
 
 Create an instance of the validator hook struct (using the hex validator as an example):
 ```go
@@ -21,9 +21,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/open-feature/golang-sdk-contrib/hooks/validator/pkg/regex"
-	"github.com/open-feature/golang-sdk-contrib/hooks/validator/pkg/validator"
-	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk-contrib/hooks/validator/pkg/regex"
+	"github.com/open-feature/go-sdk-contrib/hooks/validator/pkg/validator"
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 	"log"
 )
 
@@ -57,9 +57,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/open-feature/golang-sdk-contrib/hooks/validator/pkg/regex"
-	"github.com/open-feature/golang-sdk-contrib/hooks/validator/pkg/validator"
-	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk-contrib/hooks/validator/pkg/regex"
+	"github.com/open-feature/go-sdk-contrib/hooks/validator/pkg/validator"
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 	"log"
 )
 

--- a/hooks/validator/go.mod
+++ b/hooks/validator/go.mod
@@ -1,5 +1,5 @@
-module github.com/open-feature/golang-sdk-contrib/hooks/validator
+module github.com/open-feature/go-sdk-contrib/hooks/validator
 
 go 1.18
 
-require github.com/open-feature/golang-sdk v0.0.0-20220823155625-745a58b85574 // indirect
+require github.com/open-feature/go-sdk v0.0.0-20220823155625-745a58b85574 // indirect

--- a/hooks/validator/go.mod
+++ b/hooks/validator/go.mod
@@ -2,4 +2,4 @@ module github.com/open-feature/go-sdk-contrib/hooks/validator
 
 go 1.18
 
-require github.com/open-feature/go-sdk v0.0.0-20220823155625-745a58b85574 // indirect
+require github.com/open-feature/go-sdk v0.4.0 // indirect

--- a/hooks/validator/go.sum
+++ b/hooks/validator/go.sum
@@ -1,2 +1,4 @@
+github.com/open-feature/go-sdk v0.4.0 h1:4MC58EBEqsZRPrBfjywTEZXlgiD7lFQVSz0XIJQIRLM=
+github.com/open-feature/go-sdk v0.4.0/go.mod h1:rLTOsXIC5wJ/5iVZ0LOTz3/ahJmzxhzWcJTS81AaSqM=
 github.com/open-feature/golang-sdk v0.0.0-20220823155625-745a58b85574 h1:lm+7qW88M3/ysu07QJCca2Dei8medeZi/Zspu2VcCuM=
 github.com/open-feature/golang-sdk v0.0.0-20220823155625-745a58b85574/go.mod h1:h/XkTu6cvpYQ1Mhw2Hs1c93duGgp4c+MbwTKFu16BGM=

--- a/hooks/validator/pkg/regex/hex_test.go
+++ b/hooks/validator/pkg/regex/hex_test.go
@@ -1,8 +1,8 @@
 package regex_test
 
 import (
-	"github.com/open-feature/golang-sdk-contrib/hooks/validator/pkg/regex"
-	of "github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk-contrib/hooks/validator/pkg/regex"
+	of "github.com/open-feature/go-sdk/pkg/openfeature"
 	"testing"
 )
 

--- a/hooks/validator/pkg/regex/regex.go
+++ b/hooks/validator/pkg/regex/regex.go
@@ -2,7 +2,7 @@ package regex
 
 import (
 	"errors"
-	of "github.com/open-feature/golang-sdk/pkg/openfeature"
+	of "github.com/open-feature/go-sdk/pkg/openfeature"
 	"regexp"
 )
 

--- a/hooks/validator/pkg/validator/validator.go
+++ b/hooks/validator/pkg/validator/validator.go
@@ -1,7 +1,7 @@
 package validator
 
 import (
-	of "github.com/open-feature/golang-sdk/pkg/openfeature"
+	of "github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 type validator interface {

--- a/providers/README.md
+++ b/providers/README.md
@@ -1,4 +1,4 @@
-# OpenFeature Golang Providers
+# OpenFeature Go Providers
 
 Providers are responsible for performing flag evaluation. They provide an abstraction between the underlying flag management system and OpenFeature itself. This allows providers to be changed without requiring a major code refactor. Please see the [spec](https://github.com/open-feature/spec/blob/main/specification/provider/providers.md) for more details.
 

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -3,10 +3,10 @@
 ![Experimental](https://img.shields.io/badge/experimental-breaking%20changes%20allowed-yellow)
 ![Alpha](https://img.shields.io/badge/alpha-release-red)
 
-[Flagd](https://github.com/open-feature/flagd) is a simple command line tool for fetching and presenting feature flags to services. It is designed to conform to OpenFeature schema for flag definitions. This repository and package provides the client side code for interacting with it via the [OpenFeature SDK](https://github.com/open-feature/golang-sdk).
+[Flagd](https://github.com/open-feature/flagd) is a simple command line tool for fetching and presenting feature flags to services. It is designed to conform to OpenFeature schema for flag definitions. This repository and package provides the client side code for interacting with it via the [OpenFeature SDK](https://github.com/open-feature/go-sdk).
 
 ## Setup
-To use flagd with the [OpenFeature SDK](https://github.com/open-feature/golang-sdk) set the provider to the `openfeature` global singleton as shown below (using default values which align with those of `flagd`)
+To use flagd with the [OpenFeature SDK](https://github.com/open-feature/go-sdk) set the provider to the `openfeature` global singleton as shown below (using default values which align with those of `flagd`)
 ```go
 openfeature.SetProvider(flagd.NewProvider())
 ```  
@@ -23,8 +23,8 @@ for example:
 package main
 
 import (
-	"github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg"
-   	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
+   	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 func main() {

--- a/providers/flagd/go.mod
+++ b/providers/flagd/go.mod
@@ -1,11 +1,11 @@
-module github.com/open-feature/golang-sdk-contrib/providers/flagd
+module github.com/open-feature/go-sdk-contrib/providers/flagd
 
 go 1.18
 
 require (
 	github.com/golang/mock v1.6.0
 	github.com/open-feature/flagd v0.0.9
-	github.com/open-feature/golang-sdk v0.2.1-0.20220914084408-945bd96c8082
+	github.com/open-feature/go-sdk v0.3.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	go.buf.build/grpc/go/open-feature/flagd v1.4.2

--- a/providers/flagd/go.mod
+++ b/providers/flagd/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/golang/mock v1.6.0
 	github.com/open-feature/flagd v0.0.9
-	github.com/open-feature/go-sdk v0.3.0
+	github.com/open-feature/go-sdk v0.4.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	go.buf.build/grpc/go/open-feature/flagd v1.4.2

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service"
-	GRPCService "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/grpc"
-	HTTPService "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/http"
-	of "github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service"
+	GRPCService "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/grpc"
+	HTTPService "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/http"
+	of "github.com/open-feature/go-sdk/pkg/openfeature"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -8,8 +8,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	flagdModels "github.com/open-feature/flagd/pkg/model"
-	flagd "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg"
-	of "github.com/open-feature/golang-sdk/pkg/openfeature"
+	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
+	of "github.com/open-feature/go-sdk/pkg/openfeature"
 	schemav1 "go.buf.build/grpc/go/open-feature/flagd/schema/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 )

--- a/providers/flagd/pkg/service/grpc/client_mock_test.go
+++ b/providers/flagd/pkg/service/grpc/client_mock_test.go
@@ -1,7 +1,7 @@
 package grpc_service_test
 
 import (
-	service "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/grpc"
+	service "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/grpc"
 	schemaV1 "go.buf.build/grpc/go/open-feature/flagd/schema/v1"
 )
 

--- a/providers/flagd/pkg/service/grpc/constructor_test.go
+++ b/providers/flagd/pkg/service/grpc/constructor_test.go
@@ -3,7 +3,7 @@ package grpc_service_test
 import (
 	"testing"
 
-	service "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/grpc"
+	service "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/grpc"
 )
 
 type TestConstructorArgs struct {

--- a/providers/flagd/pkg/service/grpc/service.go
+++ b/providers/flagd/pkg/service/grpc/service.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	flagdModels "github.com/open-feature/flagd/pkg/model"
-	providerModels "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/model"
+	providerModels "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/model"
 	log "github.com/sirupsen/logrus"
 	schemaV1 "go.buf.build/grpc/go/open-feature/flagd/schema/v1"
 	"google.golang.org/grpc/status"

--- a/providers/flagd/pkg/service/grpc/service_test.go
+++ b/providers/flagd/pkg/service/grpc/service_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	models "github.com/open-feature/flagd/pkg/model"
-	service "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/grpc"
+	service "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/grpc"
 	"github.com/stretchr/testify/assert"
 	schemaV1 "go.buf.build/grpc/go/open-feature/flagd/schema/v1"
 	"google.golang.org/grpc/codes"

--- a/providers/flagd/pkg/service/grpc/service_test.go
+++ b/providers/flagd/pkg/service/grpc/service_test.go
@@ -185,8 +185,6 @@ type TestServiceResolveFloatArgs struct {
 	outReason  string
 	outVariant string
 	outValue   float64
-
-	structFormatCheck bool
 }
 
 func TestServiceResolveFloat(t *testing.T) {
@@ -341,8 +339,6 @@ type TestServiceResolveIntArgs struct {
 	outReason  string
 	outVariant string
 	outValue   int64
-
-	structFormatCheck bool
 }
 
 func TestServiceResolveInt(t *testing.T) {
@@ -497,8 +493,6 @@ type TestServiceResolveStringArgs struct {
 	outReason  string
 	outVariant string
 	outValue   string
-
-	structFormatCheck bool
 }
 
 func TestServiceResolveString(t *testing.T) {
@@ -652,8 +646,6 @@ type TestServiceResolveObjectArgs struct {
 	outReason  string
 	outVariant string
 	outValue   map[string]interface{}
-
-	structFormatCheck bool
 }
 
 func TestServiceResolveObject(t *testing.T) {

--- a/providers/flagd/pkg/service/http/constructor_test.go
+++ b/providers/flagd/pkg/service/http/constructor_test.go
@@ -3,7 +3,7 @@ package http_service_test
 import (
 	"testing"
 
-	service "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/http"
+	service "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/http"
 )
 
 type TestConstructorArgs struct {

--- a/providers/flagd/pkg/service/http/service_test.go
+++ b/providers/flagd/pkg/service/http/service_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	models "github.com/open-feature/flagd/pkg/model"
-	service "github.com/open-feature/golang-sdk-contrib/providers/flagd/pkg/service/http"
+	service "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/http"
 	"github.com/stretchr/testify/assert"
 	schemaV1 "go.buf.build/grpc/go/open-feature/flagd/schema/v1"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/providers/from-env/README.md
+++ b/providers/from-env/README.md
@@ -50,12 +50,12 @@ package main
 import (
 	"fmt"
 
-	fromEnv "github.com/open-feature/golang-sdk-contrib/providers/from-env/pkg"
-	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	fromEnv "github.com/open-feature/go-sdk-contrib/providers/from-env/pkg"
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 func main() {
-	// register the provider against the golang-sdk
+	// register the provider against the go-sdk
 	openfeature.SetProvider(&fromEnv.Provider{})
 	// create a client from via the go-sdk
 	client := openfeature.NewClient("am-i-yellow-client")

--- a/providers/from-env/go.mod
+++ b/providers/from-env/go.mod
@@ -1,5 +1,5 @@
-module github.com/open-feature/golang-sdk-contrib/providers/from-env
+module github.com/open-feature/go-sdk-contrib/providers/from-env
 
 go 1.19
 
-require github.com/open-feature/golang-sdk v0.2.1-0.20220914084408-945bd96c8082
+require github.com/open-feature/go-sdk v0.4.0 // indirect

--- a/providers/from-env/go.sum
+++ b/providers/from-env/go.sum
@@ -1,4 +1,6 @@
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/open-feature/go-sdk v0.4.0 h1:4MC58EBEqsZRPrBfjywTEZXlgiD7lFQVSz0XIJQIRLM=
+github.com/open-feature/go-sdk v0.4.0/go.mod h1:rLTOsXIC5wJ/5iVZ0LOTz3/ahJmzxhzWcJTS81AaSqM=
 github.com/open-feature/golang-sdk v0.0.0-20220823155625-745a58b85574 h1:lm+7qW88M3/ysu07QJCca2Dei8medeZi/Zspu2VcCuM=
 github.com/open-feature/golang-sdk v0.0.0-20220823155625-745a58b85574/go.mod h1:h/XkTu6cvpYQ1Mhw2Hs1c93duGgp4c+MbwTKFu16BGM=
 github.com/open-feature/golang-sdk v0.0.0-20220826131803-eb5bb27e4d8e h1:nOydvzQr+LlLvy/vxF2wbO7h114+J7Tp5/rfD+rRtWM=

--- a/providers/from-env/pkg/eval.go
+++ b/providers/from-env/pkg/eval.go
@@ -3,7 +3,7 @@ package from_env
 import (
 	"errors"
 
-	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 type StoredFlag struct {

--- a/providers/from-env/pkg/provider.go
+++ b/providers/from-env/pkg/provider.go
@@ -1,7 +1,7 @@
 package from_env
 
 import (
-	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 // FromEnvProvider implements the FeatureProvider interface and provides functions for evaluating flags

--- a/providers/from-env/pkg/provider_test.go
+++ b/providers/from-env/pkg/provider_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	fromEnv "github.com/open-feature/golang-sdk-contrib/providers/from-env/pkg"
-	"github.com/open-feature/golang-sdk/pkg/openfeature"
+	fromEnv "github.com/open-feature/go-sdk-contrib/providers/from-env/pkg"
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 // this line will fail linting if this provider is no longer compatible with the openfeature sdk


### PR DESCRIPTION
Signed-off-by: Skye Gill <gill.skye95@gmail.com>