### PR TITLE
fix!: from-env fixes and readme changes

### DIFF
--- a/providers/from-env/README.md
+++ b/providers/from-env/README.md
@@ -1,7 +1,7 @@
 # Environment Variable JSON Flag Provider
 
 This repository contains a very simple environment variable based feature flag provider.  
-This provider uses a JSON evaluation for matching a flag `Variant` to a provided `EvaluationContext`. Each flag `Variant` contains a slice of `Conditions`, if all `Conditions` match then the flags value is returned. Each `Variant` is evaluated starting at index 0, therefore the first matching `Variant` is returned. Each variant also has a `TargetingKey`, when set it must match the `TargetingKey` provided in the `EvaluationContext` for the `Variant` to be returned.  
+This provider uses a JSON evaluation for matching a flag `Variant` to a provided `EvaluationContext`. Each flag `Variant` contains a slice of `Criteria`, if all `Criteria` match then the flags value is returned. Each `Variant` is evaluated starting at index 0, therefore the first matching `Variant` is returned. Each variant also has a `TargetingKey`, when set it must match the `TargetingKey` provided in the `EvaluationContext` for the `Variant` to be returned.  
 
 
 ## Flag Configuration Structure. 
@@ -9,45 +9,52 @@ This provider uses a JSON evaluation for matching a flag `Variant` to a provided
 Flag configurations are stored as JSON strings, with one configuration per flag key. An example configuration is described below.  
 ```json
 {
-    "defaultVariant":"not-yellow",
-    "variants": [
-        {
-	    "name": "yellow-with-key",
-            "targetingKey":"user",
-            "criteria": [
-                {
-                    "color":"yellow"
-                }
-            ],
-            "value":true
-        },
-	{
-	    "name": "yellow",
-            "targetingKey":"",
-            "criteria": [
-                {
-                    "color":"yellow"
-                }
-            ],
-            "value":true
-        },
-        {
-	    "name": "not-yellow",
-            "targetingKey":"",
-            "criteria": [],
-            "value":false
-        }
-    ]
+	"defaultVariant": "not-yellow",
+	"variants": [
+		{
+			"name": "yellow-with-key",
+			"targetingKey": "user",
+			"criteria": [
+				{
+					"key": "color",
+					"value": "yellow"
+				}
+			],
+			"value": true
+		},
+		{
+			"name": "yellow",
+			"targetingKey": "",
+			"criteria": [
+				{
+					"key": "color",
+					"value": "yellow"
+				}
+			],
+			"value": true
+		},
+		{
+			"name": "not-yellow",
+			"targetingKey": "",
+			"criteria": [],
+			"value": false
+		}
+	]
 }
 ```
 
 ## Example Usage  
 Below is a simple example of using this `Provider`, in this example the above flag configuration is saved with the key `AM_I_YELLOW.` 
 
+```
+export AM_I_YELLOW='{"defaultVariant":"not-yellow","variants":[{"name":"yellow-with-key","targetingKey":"user","criteria":[{"key":"color","value":"yellow"}],"value":true},{"name":"yellow","targetingKey":"","criteria":[{"key":"color","value":"yellow"}],"value":true},{"name":"not-yellow","targetingKey":"","criteria": [],"value":false}]}'
+```
+
 ```go
 package main
 
 import (
+	"context"
 	"fmt"
 
 	fromEnv "github.com/open-feature/go-sdk-contrib/providers/from-env/pkg"
@@ -56,12 +63,13 @@ import (
 
 func main() {
 	// register the provider against the go-sdk
-	openfeature.SetProvider(&fromEnv.Provider{})
+	openfeature.SetProvider(&fromEnv.FromEnvProvider{})
 	// create a client from via the go-sdk
 	client := openfeature.NewClient("am-i-yellow-client")
 
 	// we are now able to evaluate our stored flags
-	res, err := client.BooleanValueDetails(
+	resB, err := client.BooleanValueDetails(
+		context.Background(),
 		"AM_I_YELLOW",
 		false,
 		openfeature.NewEvaluationContext(
@@ -71,21 +79,23 @@ func main() {
 			},
 		),
 	)
-	fmt.Println(res, err)
+	fmt.Println(resB, err)
 
-	res, err := client.BooleanValueDetails(
-        "AM_I_YELLOW",
-        false,
-        openfeature.NewEvaluationContext(
-            "user",
-            map[string]interface{}{
-                "color": "yellow",
-            },
-        ),
+	resB, err = client.BooleanValueDetails(
+		context.Background(),
+		"AM_I_YELLOW",
+		false,
+		openfeature.NewEvaluationContext(
+			"user",
+			map[string]interface{}{
+				"color": "yellow",
+			},
+		),
 	)
-	fmt.Println(res, err)
+	fmt.Println(resB, err)
 
-	res, err = client.StringValueDetails(
+	resS, err := client.StringValueDetails(
+		context.Background(),
 		"AM_I_YELLOW",
 		"i am a default value",
 		openfeature.NewEvaluationContext(
@@ -95,14 +105,15 @@ func main() {
 			},
 		),
 	)
-	fmt.Println(res, err)
+	fmt.Println(resS, err)
 }
+
 ```
 Console output:
 ```
 {AM_I_YELLOW 0 {true  TARGETING_MATCH yellow}} <nil>
 {AM_I_YELLOW 0 {true  TARGETING_MATCH yellow-with-key}} <nil>
-{AM_I_YELLOW 1 {i am a default value   }} evaluate the flag: TYPE_MISMATCH
+{i am a default value {AM_I_YELLOW string { ERROR TYPE_MISMATCH }}} error code: TYPE_MISMATCH
 ```
 
 ## Common Error Response Types

--- a/providers/from-env/pkg/eval.go
+++ b/providers/from-env/pkg/eval.go
@@ -6,7 +6,7 @@ import (
 
 type StoredFlag struct {
 	DefaultVariant string    `json:"defaultVariant"`
-	Variants       []Variant `json:"variant"`
+	Variants       []Variant `json:"variants"`
 }
 
 type Variant struct {
@@ -25,7 +25,8 @@ func (f *StoredFlag) evaluate(evalCtx map[string]interface{}) (string, openfeatu
 	var defaultVariant *Variant
 	for _, variant := range f.Variants {
 		if variant.Name == f.DefaultVariant {
-			defaultVariant = &variant
+			v := variant
+			defaultVariant = &v
 		}
 		if variant.TargetingKey != "" && variant.TargetingKey != evalCtx["targetingKey"] {
 			continue


### PR DESCRIPTION
Signed-off-by: James Milligan <james@omnant.co.uk>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- updates `variant` to `variants` in the stored flag structure.
- fixes issues with the readme.
- adds casting to range over pointer slice, causing issues with the wrong values being returned for default variants.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/go-sdk-contrib/issues/45
https://github.com/open-feature/go-sdk-contrib/issues/46
https://github.com/open-feature/go-sdk-contrib/issues/47

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

