### PR TITLE
fix: Purge cache if config change event handling fails

### DIFF
--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -459,7 +459,10 @@ func (p *Provider) handleEvents(ctx context.Context) error {
 			switch event.Type {
 			case string(flagdService.ConfigurationChange):
 				if err := p.handleConfigurationChangeEvent(ctx, event); err != nil {
-					log.Errorf("handle configuration change event: %v", err)
+					// Purge the cache if we fail to handle the configuration change event
+					p.cache.Purge()
+
+					log.Warningf("handle configuration change event: %v", err)
 				}
 			case string(flagdService.ProviderReady): // signals that a new connection has been made
 				p.handleProviderReadyEvent()


### PR DESCRIPTION
## This PR

Fixes #84

Changed the log level to warning as we purge the cache, allowing fresh flags to be fetched from the provider. 

### Notes

Tests were not added as testing the workflow is tough. 
