### PR TITLE
refactor: Handle context done channel

### DIFF
--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -473,7 +473,7 @@ func (p *Provider) handleEvents(ctx context.Context) error {
 			}
 			return err
 		case <-ctx.Done():
-			log.Info("Stop event handling with context done.")
+			log.Info("stop event handling with context done")
 
 			return nil
 		}

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -472,6 +472,10 @@ func (p *Provider) handleEvents(ctx context.Context) error {
 				WithoutCache()(p)
 			}
 			return err
+		case <-ctx.Done():
+			log.Info("Stop event handling with context done.")
+
+			return nil
 		}
 	}
 }

--- a/providers/flagd/pkg/service/service.go
+++ b/providers/flagd/pkg/service/service.go
@@ -203,7 +203,7 @@ func (s *Service) EventStream(
 	var err error
 	for i := 1; i <= maxAttempts; i++ {
 		log.Infof("attempt %d at connecting to event stream", i)
-		i, err = s.eventStream(ctx, eventChan, i, maxAttempts)
+		i, err = s.eventStream(ctx, eventChan, i)
 		if i == 1 {
 			delay = s.baseRetryDelay // reset delay if the connection was successful before failing
 		}
@@ -220,8 +220,7 @@ func (s *Service) EventStream(
 }
 
 func (s *Service) eventStream(
-	ctx context.Context, eventChan chan<- *schemaV1.EventStreamResponse, attempt, maxAttempts int,
-) (int, error) {
+	ctx context.Context, eventChan chan<- *schemaV1.EventStreamResponse, attempt int) (int, error) {
 	client := s.Client.Instance()
 	if client == nil {
 		return attempt + 1, openfeature.NewProviderNotReadyResolutionError(ConnectionError)


### PR DESCRIPTION
This was observed while attempting to introduce unit tests on flagD configuration change event handling. 

Further, removed an unused variable within `Service` event handler. 