### PR TITLE
feat: Update provider to be compatible with GO Feature Flag v1.0.0

### DIFF
--- a/providers/go-feature-flag/go.mod
+++ b/providers/go-feature-flag/go.mod
@@ -5,16 +5,17 @@ go 1.18
 require (
 	github.com/open-feature/go-sdk v1.1.0
 	github.com/stretchr/testify v1.8.1
-	github.com/thomaspoignant/go-feature-flag v0.28.2
+	github.com/thomaspoignant/go-feature-flag v1.0.0
 )
 
 require (
+	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20220911224424-aa1f1f12a846 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/nikunjy/rules v1.0.1-0.20220920033320-71e8e569642c // indirect
+	github.com/nikunjy/rules v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect

--- a/providers/go-feature-flag/go.sum
+++ b/providers/go-feature-flag/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.104.0 h1:gSmWO7DY1vOm0MVU6DNXM11BWHHsTUmsC5cv1fuW5X8=
 cloud.google.com/go/compute v1.7.0 h1:v/k9Eueb8aAJ0vZuxKMrgm6kPhCLZU9HxFU+AFDs9Uk=
 cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/storage v1.27.0 h1:YOO045NZI9RKfCj1c5A/ZtuuENUc8OAW+gHdGnDgyMQ=
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20220911224424-aa1f1f12a846 h1:et5J11AOyUn9qwkIAF9kcxTxjTO8Z9oSmlOqH7MVSPo=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20220911224424-aa1f1f12a846/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/aws/aws-sdk-go v1.44.109 h1:+Na5JPeS0kiEHoBp5Umcuuf+IDqXqD0lXnM920E31YI=
@@ -23,6 +25,8 @@ github.com/googleapis/gax-go/v2 v2.5.1 h1:kBRZU0PSuI7PspsSb/ChWoVResUcwNVIdpB049
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/nikunjy/rules v1.0.1-0.20220920033320-71e8e569642c h1:984E5FSs5smzVlxNcl9t9s8xgkrdXPgmLlpLoaK3/zI=
 github.com/nikunjy/rules v1.0.1-0.20220920033320-71e8e569642c/go.mod h1:Up4dDdLmEJoIttEZll8NtFuo6EmFrMxAwF0VRLcdlLU=
+github.com/nikunjy/rules v1.2.0 h1:5BhojNDpsHLgFlvVRT8e9wKIPcWehUf4nf+cOKlrRxc=
+github.com/nikunjy/rules v1.2.0/go.mod h1:Up4dDdLmEJoIttEZll8NtFuo6EmFrMxAwF0VRLcdlLU=
 github.com/open-feature/go-sdk v1.0.1 h1:gT2rUJxmqO4jh1CYGPBfyEySi9woXsP9B773y8Y/iAo=
 github.com/open-feature/go-sdk v1.0.1/go.mod h1:Ub7Bu2yjBFieDMQJZXoOV+x6Mhn9pudxG1CR7zsHBUg=
 github.com/open-feature/go-sdk v1.1.0 h1:JOOa0AleJFUvnWoF9KWdLqYosi5fDIRBDzPYZPr5qgM=
@@ -42,6 +46,8 @@ github.com/thomaspoignant/go-feature-flag v0.28.1 h1:JbMAjyCLLAKXWzlScd2lu3/zuJ0
 github.com/thomaspoignant/go-feature-flag v0.28.1/go.mod h1:MXobTPVseHQ5O1CbICuDE2JWulOn5JjL5SGdPjHKIKI=
 github.com/thomaspoignant/go-feature-flag v0.28.2 h1:+NGD3K6w6gnJZgREW+jseLWkawttbEQrPxEBJNUa8pM=
 github.com/thomaspoignant/go-feature-flag v0.28.2/go.mod h1:gM5Ur7YW6262Sp+ICkB0IlpMjNKmQmC6KvjzmwPv/nE=
+github.com/thomaspoignant/go-feature-flag v1.0.0 h1:yy1I+o59iIU81zHO37E9YXOhCL8lx3XIRORbBrEKJ3I=
+github.com/thomaspoignant/go-feature-flag v1.0.0/go.mod h1:7EVzKjQf+EdXmHGOUyhxwiVK1AXXWNYYPM/tezXEI6g=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=

--- a/providers/go-feature-flag/pkg/model/eval_response.go
+++ b/providers/go-feature-flag/pkg/model/eval_response.go
@@ -4,7 +4,7 @@ type EvalResponse[T JsonType] struct {
 	TrackEvents   bool   `json:"trackEvents"`
 	VariationType string `json:"variationType"`
 	Failed        bool   `json:"failed"`
-	Version       int    `json:"version"`
+	Version       string `json:"version"`
 	Reason        string `json:"reason"`
 	ErrorCode     string `json:"errorCode"`
 	Value         T      `json:"value"`

--- a/providers/go-feature-flag/pkg/provider_test.go
+++ b/providers/go-feature-flag/pkg/provider_test.go
@@ -205,7 +205,7 @@ func TestProvider_BooleanEvaluation(t *testing.T) {
 					ResolutionDetail: of.ResolutionDetail{
 						Reason:       of.ErrorReason,
 						ErrorCode:    of.ParseErrorCode,
-						ErrorMessage: "impossible to parse response for flag invalid_json_body: {\n  \"trackEvents\": true,\n  \"variationType\": \"True\",\n  \"failed\": false,\n  \"version\": 0,\n  \"reason\": \"TARGETING_MATCH\",\n  \"errorCode\": \"\",\n  \"value\": true\n",
+						ErrorMessage: "impossible to parse response for flag invalid_json_body: {\n  \"trackEvents\": true,\n  \"variationType\": \"True\",\n  \"failed\": false,\n  \"version\": \"\",\n  \"reason\": \"TARGETING_MATCH\",\n  \"errorCode\": \"\",\n  \"value\": true\n",
 					},
 				},
 			},

--- a/providers/go-feature-flag/testutils/mock_responses/bool_targeting_match.json
+++ b/providers/go-feature-flag/testutils/mock_responses/bool_targeting_match.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": true

--- a/providers/go-feature-flag/testutils/mock_responses/disabled_bool.json
+++ b/providers/go-feature-flag/testutils/mock_responses/disabled_bool.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "defaultSdk",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "DISABLED",
   "errorCode": "",
   "value": false

--- a/providers/go-feature-flag/testutils/mock_responses/disabled_float.json
+++ b/providers/go-feature-flag/testutils/mock_responses/disabled_float.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "defaultSdk",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "DISABLED",
   "errorCode": "",
   "value": 123.45

--- a/providers/go-feature-flag/testutils/mock_responses/disabled_int.json
+++ b/providers/go-feature-flag/testutils/mock_responses/disabled_int.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "defaultSdk",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "DISABLED",
   "errorCode": "",
   "value": 123

--- a/providers/go-feature-flag/testutils/mock_responses/disabled_string.json
+++ b/providers/go-feature-flag/testutils/mock_responses/disabled_string.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "defaultSdk",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "DISABLED",
   "errorCode": "",
   "value": "default"

--- a/providers/go-feature-flag/testutils/mock_responses/double_key.json
+++ b/providers/go-feature-flag/testutils/mock_responses/double_key.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": 100.25

--- a/providers/go-feature-flag/testutils/mock_responses/flag_not_found.json
+++ b/providers/go-feature-flag/testutils/mock_responses/flag_not_found.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "SdkDefault",
   "failed": true,
-  "version": 0,
+  "version": "",
   "reason": "ERROR",
   "errorCode": "FLAG_NOT_FOUND"
 }

--- a/providers/go-feature-flag/testutils/mock_responses/integer_key.json
+++ b/providers/go-feature-flag/testutils/mock_responses/integer_key.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": 100

--- a/providers/go-feature-flag/testutils/mock_responses/invalid_json_body.json
+++ b/providers/go-feature-flag/testutils/mock_responses/invalid_json_body.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": true

--- a/providers/go-feature-flag/testutils/mock_responses/list_key.json
+++ b/providers/go-feature-flag/testutils/mock_responses/list_key.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": [

--- a/providers/go-feature-flag/testutils/mock_responses/object_key.json
+++ b/providers/go-feature-flag/testutils/mock_responses/object_key.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": {

--- a/providers/go-feature-flag/testutils/mock_responses/string_key.json
+++ b/providers/go-feature-flag/testutils/mock_responses/string_key.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "TARGETING_MATCH",
   "errorCode": "",
   "value": "CC0000"

--- a/providers/go-feature-flag/testutils/mock_responses/unknown_reason.json
+++ b/providers/go-feature-flag/testutils/mock_responses/unknown_reason.json
@@ -2,7 +2,7 @@
   "trackEvents": true,
   "variationType": "True",
   "failed": false,
-  "version": 0,
+  "version": "",
   "reason": "CUSTOM_REASON",
   "errorCode": "",
   "value": true

--- a/providers/go-feature-flag/testutils/module/flags.yaml
+++ b/providers/go-feature-flag/testutils/module/flags.yaml
@@ -1,76 +1,134 @@
 bool_targeting_match:
-  true: true
-  false: false
-  default: false
-  percentage: 100
-
+  variations:
+    Default: false
+    "False": false
+    "True": true
+  targeting:
+    - query: email eq "john.doe@gofeatureflag.org"
+      variation: "True"
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
 disabled_bool:
-  true: true
-  false: false
-  default: false
-  percentage: 100
+  variations:
+    Default: false
+    "False": false
+    "True": true
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
   disable: true
-
-string_key:
-  true: "CC0000"
-  false: "CC0001"
-  default: "CC0002"
-  percentage: 100
-
-disabled_string:
-  true: "CC0000"
-  false: "CC0001"
-  default: "CC0002"
-  percentage: 100
-  disable: true
-
-double_key:
-  true: 100.25
-  false: 101.25
-  default: 103.25
-  percentage: 100
-
 disabled_float:
-  true: 100.25
-  false: 101.25
-  default: 103.25
-  percentage: 100
+  variations:
+    Default: 103.25
+    "False": 101.25
+    "True": 100.25
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
   disable: true
-
-integer_key:
-  true: 100
-  false: 101
-  default: 103
-  percentage: 100
-
 disabled_int:
-  true: 100
-  false: 101
-  default: 103
-  percentage: 100
+  variations:
+    Default: 103
+    "False": 101
+    "True": 100
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
   disable: true
-
-object_key:
-  percentage: 100
-  true:
-    test:  test1
-    test2: false
-    test3: 123.3
-    test4: 1
-  false:
-    test:  "false"
-  default:
-    test: "default"
-
 disabled_interface:
-  percentage: 100
-  true:
-    test: test1
-    test2: false
-    test3: 123.3
-    test4: 1
-  false:
-    test: "false"
-  default:
-    test: "default"
+  variations:
+    Default:
+      test: default
+    "False":
+      test: "false"
+    "True":
+      test: test1
+      test2: false
+      test3: 123.3
+      test4: 1
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
   disable: true
+disabled_string:
+  variations:
+    Default: CC0002
+    "False": CC0001
+    "True": CC0000
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
+  disable: true
+double_key:
+  variations:
+    Default: 103.25
+    "False": 101.25
+    "True": 100.25
+  targeting:
+    - query: email eq "john.doe@gofeatureflag.org"
+      variation: "True"
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
+integer_key:
+  variations:
+    Default: 103
+    "False": 101
+    "True": 100
+  targeting:
+    - query: email eq "john.doe@gofeatureflag.org"
+      variation: "True"
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
+object_key:
+  variations:
+    Default:
+      test: default
+    "False":
+      test: "false"
+    "True":
+      test: test1
+      test2: false
+      test3: 123.3
+      test4: 1
+  targeting:
+    - query: email eq "john.doe@gofeatureflag.org"
+      variation: "True"
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
+string_key:
+  variations:
+    Default: CC0002
+    "False": CC0001
+    "True": CC0000
+  targeting:
+    - query: email eq "john.doe@gofeatureflag.org"
+      variation: "True"
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100
+string_key_with_version:
+  variations:
+    Default: CC0002
+    "False": CC0001
+    "True": CC0000
+  targeting:
+    - query: email eq "john.doe@gofeatureflag.org"
+      variation: "True"
+  defaultRule:
+    percentage:
+      "False": 0
+      "True": 100


### PR DESCRIPTION
## This PR
This PR is upgrading the GO Feature Flag provider with version `1.0.0`.

### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/488

### Notes
We can close the renovate issue https://github.com/open-feature/go-sdk-contrib/pull/101 because this one is also taking care of the upgrade.
