### PR TITLE
feat: allow ProviderOptions to be given to scenario initializations

### DIFF
--- a/tests/flagd/pkg/integration/caching.go
+++ b/tests/flagd/pkg/integration/caching.go
@@ -19,7 +19,8 @@ var (
 )
 
 // InitializeCachingScenario initializes the caching test scenario
-func InitializeCachingScenario(flagConfigPath string) (func(*godog.ScenarioContext), error) {
+func InitializeCachingScenario(flagConfigPath string, pOptions ...flagd.ProviderOption) (func(*godog.ScenarioContext), error) {
+	providerOptions = pOptions
 	flagConfigurationPath = flagConfigPath
 	var err error
 	testingFlags, err = loadFlagConfiguration(flagConfigPath)
@@ -262,7 +263,9 @@ func resetState(ctx context.Context, sc *godog.Scenario) (context.Context, error
 }
 
 func aProviderIsRegisteredWithCacheEnabled(ctx context.Context) (context.Context, error) {
-	provider := flagd.NewProvider(flagd.WithPort(8013))
+	pOptions := []flagd.ProviderOption{flagd.WithPort(8013)}
+	pOptions = append(pOptions, providerOptions...)
+	provider := flagd.NewProvider(pOptions...)
 	openfeature.SetProvider(provider)
 	client := openfeature.NewClient("caching tests")
 

--- a/tests/flagd/pkg/integration/evaluation.go
+++ b/tests/flagd/pkg/integration/evaluation.go
@@ -12,8 +12,14 @@ import (
 	"time"
 )
 
+func InitializeEvaluationScenario(pOptions ...flagd.ProviderOption) func(*godog.ScenarioContext) {
+	providerOptions = pOptions
+
+	return initializeEvaluationScenario
+}
+
 // InitializeEvaluationScenario initializes the evaluation test scenario
-func InitializeEvaluationScenario(ctx *godog.ScenarioContext) {
+func initializeEvaluationScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^a provider is registered with cache disabled$`, aProviderIsRegisteredWithCacheDisabled)
 
 	ctx.Step(`^a boolean flag with key "([^"]*)" is evaluated with default value "([^"]*)"$`, aBooleanFlagWithKeyIsEvaluatedWithDefaultValue)
@@ -650,7 +656,9 @@ func theReasonShouldIndicateAnErrorAndTheErrorCodeShouldIndicateATypeMismatchWit
 }
 
 func aProviderIsRegisteredWithCacheDisabled(ctx context.Context) (context.Context, error) {
-	provider := flagd.NewProvider(flagd.WithPort(8013), flagd.WithoutCache())
+	pOptions := []flagd.ProviderOption{flagd.WithPort(8013), flagd.WithoutCache()}
+	pOptions = append(pOptions, providerOptions...)
+	provider := flagd.NewProvider(pOptions...)
 	openfeature.SetProvider(provider)
 	client := openfeature.NewClient("evaluation tests")
 

--- a/tests/flagd/pkg/integration/integration.go
+++ b/tests/flagd/pkg/integration/integration.go
@@ -3,8 +3,11 @@ package integration
 import (
 	"context"
 	"errors"
+	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
+
+var providerOptions []flagd.ProviderOption
 
 // ctxStorageKey is the key used to pass test data across context.Context
 type ctxStorageKey struct{}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Allow ProviderOptions to be given to scenario initializations (e.g. for use by TLS testing)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->
This is a breaking change but as this module is only used internally by go-sdk/flagd the pain of upgrading to the next major version in Go is not worth it.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

- [ ] Absorb changes in flagd https://github.com/open-feature/flagd/pull/312
- [ ] Absorb changes in go-sdk

### How to test
<!-- if applicable, add testing instructions under this section -->

