### PR TITLE
chore: upgrade go-sdk to v1.3.0. enforce otel hook to be valid Hook at compile time

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -1,11 +1,17 @@
 # OpenTelemetry Hook
 
+### Requirements
+
+- open-feature/go-sdk >= v1.3.0
+
+## Usage
+
 For this hook to function correctly a global `TracerProvider` must be set, an example of how to do this can be found below.
 
 The `open telemetry hook` taps into the after and error methods of the hook lifecycle to write `events` and `attributes` to an existing `span`.
 A `context.Context` containing a `span` must be passed to the client evaluation method, otherwise the hook will no-op.
 
-## Example
+### Example
 The following example demonstrates the use of the `OpenTelemetry hook` with the `OpenFeature go-sdk`. The traces are sent to a `zipkin` server running at `:9411` which will receive the following trace:
 ```json
 {

--- a/hooks/open-telemetry/go.mod
+++ b/hooks/open-telemetry/go.mod
@@ -3,7 +3,7 @@ module github.com/open-feature/go-sdk-contrib/hooks/open-telemetry
 go 1.19
 
 require (
-	github.com/open-feature/go-sdk v1.2.0
+	github.com/open-feature/go-sdk v1.3.0
 	go.opentelemetry.io/otel v1.12.0
 	go.opentelemetry.io/otel/sdk v1.12.0
 	go.opentelemetry.io/otel/trace v1.12.0
@@ -12,5 +12,5 @@ require (
 require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.5.0 // indirect
 )

--- a/hooks/open-telemetry/go.sum
+++ b/hooks/open-telemetry/go.sum
@@ -10,6 +10,8 @@ github.com/open-feature/go-sdk v1.1.0 h1:JOOa0AleJFUvnWoF9KWdLqYosi5fDIRBDzPYZPr
 github.com/open-feature/go-sdk v1.1.0/go.mod h1:R8QJmLdSHFaRdrWtwmp5bVK35Q+O/cEGtYaiy6NM6kc=
 github.com/open-feature/go-sdk v1.2.0 h1:2xsUgNUUDITpryB9nFS43CI9gAF415I1He22Q1d4+Po=
 github.com/open-feature/go-sdk v1.2.0/go.mod h1:UQJJXUptk92An4F6so2Vd0iRo6EEZ+QGa7HVyQ/GPi0=
+github.com/open-feature/go-sdk v1.3.0 h1:SiIS0ElVZTjbmHZB1/5Fm5mBRIqoYD+c2jVdw+D+Qok=
+github.com/open-feature/go-sdk v1.3.0/go.mod h1:hEOzRFh23MH+IZttR9+zyf5jBzotxxxcCjnk/wBH2H0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.opentelemetry.io/otel v1.11.2 h1:YBZcQlsVekzFsFbjygXMOXSs6pialIZxcjfO/mBDmR0=
@@ -26,5 +28,6 @@ go.opentelemetry.io/otel/trace v1.12.0 h1:p28in++7Kd0r2d8gSt931O57fdjUyWxkVbESuI
 go.opentelemetry.io/otel/trace v1.12.0/go.mod h1:pHlgBynn6s25qJ2szD+Bv+iwKJttjHSI3lUAyf0GNuQ=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/hooks/open-telemetry/pkg/otel.go
+++ b/hooks/open-telemetry/pkg/otel.go
@@ -40,3 +40,5 @@ func (h *hook) Error(ctx context.Context, hookContext openfeature.HookContext, e
 	span := trace.SpanFromContext(ctx)
 	span.RecordError(err)
 }
+
+var _ openfeature.Hook = &hook{}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- upgrade go-sdk to v1.3.0
- enforce otel hook to be valid Hook at compile time

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #116 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

