### PR TITLE
ci: separate PRs for releases and extended release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
     "monorepo-tags": true,
     "tag-separator": "/",
     "bootstrap-sha": "4d6cb816ed912084c598767636324aa9a2866bdd",
+    "separate-pull-requests": true,
     "packages": {
         "hooks/open-telemetry": {
             "release-type": "go",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -51,5 +51,60 @@
             "versioning": "default",
             "extra-files": []
         }
-    }
+    },
+    "changelog-sections": [
+      {
+        "type": "fix",
+        "section": "🐛 Bug Fixes"
+      },
+      {
+        "type": "feat",
+        "section": "✨ New Features"
+      },
+      {
+        "type": "chore",
+        "section": "🧹 Chore"
+      },
+      {
+        "type": "docs",
+        "section": "📚 Documentation"
+      },
+      {
+        "type": "perf",
+        "section": "🚀 Performance"
+      },
+      {
+        "type": "build",
+        "hidden": true,
+        "section": "🛠️ Build"
+      },
+      {
+        "type": "deps",
+        "section": "📦 Dependencies"
+      },
+      {
+        "type": "ci",
+        "hidden": true,
+        "section": "🚦 CI"
+      },
+      {
+        "type": "refactor",
+        "section": "🔄 Refactoring"
+      },
+      {
+        "type": "revert",
+        "section": "🔙 Reverts"
+      },
+      {
+        "type": "style",
+        "hidden": true,
+        "section": "🎨 Styling"
+      },
+      {
+        "type": "test",
+        "hidden": true,
+        "section": "🧪 Tests"
+      }
+  ],
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
## This PR

- extends release notes
- add separate PRs per release artifact

### Notes

This has been done in other repos and has been well received.

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>
