### PR TITLE
feat: Support apiKey for GO Feature Flag relay proxy v1.7.0

### DIFF
--- a/providers/go-feature-flag/pkg/provider_options.go
+++ b/providers/go-feature-flag/pkg/provider_options.go
@@ -16,4 +16,10 @@ type ProviderOptions struct {
 	// GOFeatureFlagConfig is the configuration struct for the GO Feature Flag module.
 	// If not nil we will launch the provider using the GO Feature Flag module.
 	GOFeatureFlagConfig *ffclient.Config
+
+	// APIKey  (optional) If the relay proxy is configured to authenticate the requests, you should provide
+	// an API Key to the provider. Please ask the administrator of the relay proxy to provide an API Key.
+	// (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
+	// Default: null
+	APIKey string
 }


### PR DESCRIPTION
## This PR
Support apiKey for GO Feature Flag relay proxy v1.7.0

### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/666