### PR TITLE
test: zero value unit tests

### DIFF
--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -3,9 +3,10 @@ package flagd
 import (
 	"context"
 	"fmt"
-	"github.com/golang/mock/gomock"
 	reflect "reflect"
 	"testing"
+
+	"github.com/golang/mock/gomock"
 
 	schemav1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/schema/v1"
 	flagdModels "github.com/open-feature/flagd/pkg/model"
@@ -144,6 +145,27 @@ func TestBooleanEvaluation(t *testing.T) {
 				ProviderResolutionDetail: of.ProviderResolutionDetail{
 					Reason:          flagdModels.DefaultReason,
 					ResolutionError: of.NewFlagNotFoundResolutionError(""),
+				},
+			},
+		},
+		// flagd does not contain a value field in its response for go zero values (false)
+		{
+			name:         "zero value response",
+			flagKey:      "flag",
+			defaultValue: true,
+			evalCtx: map[string]interface{}{
+				"food": "bars",
+			},
+			mockOut: &schemav1.ResolveBooleanResponse{
+				Variant: "on",
+				Reason:  flagdModels.DefaultReason,
+			},
+			mockError: nil,
+			response: of.BoolResolutionDetail{
+				Value: false,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					Variant: "on",
+					Reason:  flagdModels.DefaultReason,
 				},
 			},
 		},
@@ -317,6 +339,27 @@ func TestFloatEvaluation(t *testing.T) {
 				},
 			},
 		},
+		// flagd does not contain a value field in its response for go zero values
+		{
+			name:         "zero value response",
+			flagKey:      "flag",
+			defaultValue: 1,
+			evalCtx: map[string]interface{}{
+				"food": "bars",
+			},
+			mockOut: &schemav1.ResolveFloatResponse{
+				Variant: "zero",
+				Reason:  flagdModels.DefaultReason,
+			},
+			mockError: nil,
+			response: of.FloatResolutionDetail{
+				Value: 0,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					Variant: "zero",
+					Reason:  flagdModels.DefaultReason,
+				},
+			},
+		},
 	}
 
 	ctrl := gomock.NewController(t)
@@ -398,6 +441,27 @@ func TestIntEvaluation(t *testing.T) {
 				ProviderResolutionDetail: of.ProviderResolutionDetail{
 					Reason:          flagdModels.DefaultReason,
 					ResolutionError: of.NewFlagNotFoundResolutionError(""),
+				},
+			},
+		},
+		// flagd does not contain a value field in its response for go zero values
+		{
+			name:         "zero value response",
+			flagKey:      "flag",
+			defaultValue: 1,
+			evalCtx: map[string]interface{}{
+				"food": "bars",
+			},
+			mockOut: &schemav1.ResolveIntResponse{
+				Variant: "on",
+				Reason:  flagdModels.DefaultReason,
+			},
+			mockError: nil,
+			response: of.IntResolutionDetail{
+				Value: 0,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					Variant: "on",
+					Reason:  flagdModels.DefaultReason,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- introduces unit tests to ensure [go zero values](https://go.dev/tour/basics/12) are returned when the evaluation response is missing the `Value` field for `int` `float` and `bool` evaluations

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/go-sdk-contrib/issues/43

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

