### PR TITLE
chore: set LD initial version & update contrib doc

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
     "providers/from-env": "0.1.2",
     "providers/go-feature-flag": "0.1.11",
     "providers/flagsmith": "0.1.2",
+    "providers/launchdarkly": "0.1.0",
     "tests/flagd": "1.2.1"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,13 @@ create and setup new hook directory (requires jq)
 make MODULE_NAME=NAME new-hook 
 ```
 
-[jq documentation](https://stedolan.github.io/jq/download/)
+Note - [jq documentation](https://stedolan.github.io/jq/download/)
+
+### Versioning
+
+The release version of the newly added module(hook/provider) is controlled by `.release-please-manifest.json`. You can 
+control the versioning of your module by adding an entry  with desired initial version(ex: `"provider/acme":"0.0.1"` ). 
+Otherwise, default versioning will start from `1.0.0`.
 
 ## Documentation
 


### PR DESCRIPTION
## This PR

Helps to set the initial version of LD release [1] . Plus adds documentation entry to explain the versioning of releases 


[1]- https://github.com/open-feature/go-sdk-contrib/pull/184