### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -40,6 +40,12 @@ jobs:
           version: v1
           args: mod -licenses -json -output bom.json ${{ matrix.release }}
       # Create licenses artifacts
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Setup workspace
+        run: make workspace-init
       - name: Install go-licenses
         run: go install github.com/google/go-licenses@latest
       - name: Define license extraction locations


### PR DESCRIPTION
## This PR

Fixes failing release workflow [1] due to go environment unavailability. This is required for go-licenses installation.

Further, `go-licenses` require module dependency to be resolved, hence the execution of workspace initialization through make command

[1] - https://github.com/open-feature/go-sdk-contrib/actions/runs/4941452207/jobs/8834069484