### PR TITLE
fix: set error state with a message

### DIFF
--- a/hooks/open-telemetry/pkg/otel.go
+++ b/hooks/open-telemetry/pkg/otel.go
@@ -2,9 +2,10 @@ package otel
 
 import (
 	"context"
-
+	"fmt"
 	"github.com/open-feature/go-sdk/pkg/openfeature"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -38,6 +39,8 @@ func (h *hook) After(ctx context.Context, hookContext openfeature.HookContext, f
 // Error records the given error against the span and sets the span to an error status
 func (h *hook) Error(ctx context.Context, hookContext openfeature.HookContext, err error, hookHints openfeature.HookHints) {
 	span := trace.SpanFromContext(ctx)
+	span.SetStatus(codes.Error,
+		fmt.Sprintf("error evaluating flag '%s' of type '%s'", hookContext.FlagKey(), hookContext.FlagType().String()))
 	span.RecordError(err)
 }
 


### PR DESCRIPTION
## This PR

Fixes #204. Consider following Jaeger trace for state & error message 

![image](https://github.com/open-feature/go-sdk-contrib/assets/8186721/505334d8-2a5f-4d9b-bbc8-be4d9ad93267)
