### PR TITLE
feat: otel hook error status override option

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -13,8 +13,8 @@ A `context.Context` containing a `span` must be passed to the client evaluation 
 
 ### Options
 
-- WithErrorStatusDisabled: prevents setting span status to `Error` in case of an error. Default behavior is enabled, 
-  span status is set to `Error` if error occurs
+- WithErrorStatusEnabled: enable setting span status to `Error` in case of an error. Default behavior is disabled, 
+  span status is unset for errors.
 
 ### Example
 The following example demonstrates the use of the `OpenTelemetry hook` with the `OpenFeature go-sdk`. The traces are sent to a `zipkin` server running at `:9411` which will receive the following trace:

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -11,6 +11,11 @@ For this hook to function correctly a global `TracerProvider` must be set, an ex
 The `open telemetry hook` taps into the after and error methods of the hook lifecycle to write `events` and `attributes` to an existing `span`.
 A `context.Context` containing a `span` must be passed to the client evaluation method, otherwise the hook will no-op.
 
+### Options
+
+- WithErrorStatusDisabled: prevents setting span status to `Error` in case of an error. Default behavior is enabled, 
+  span status is set to `Error` if error occurs
+
 ### Example
 The following example demonstrates the use of the `OpenTelemetry hook` with the `OpenFeature go-sdk`. The traces are sent to a `zipkin` server running at `:9411` which will receive the following trace:
 ```json

--- a/hooks/open-telemetry/pkg/otel.go
+++ b/hooks/open-telemetry/pkg/otel.go
@@ -23,9 +23,7 @@ type hook struct {
 
 // NewHook return a reference to a new instance of the OpenTelemetry Hook
 func NewHook(opts ...Options) *hook {
-	h := &hook{
-		setErrorStatus: true,
-	}
+	h := &hook{}
 
 	for _, opt := range opts {
 		opt(h)
@@ -61,10 +59,10 @@ func (h *hook) Error(ctx context.Context, hookContext openfeature.HookContext, e
 
 type Options func(*hook)
 
-// WithErrorStatusDisabled prevents setting span status to codes.Error in case of an error. Default behavior is enabled
-func WithErrorStatusDisabled() Options {
+// WithErrorStatusEnabled enable setting span status to codes.Error in case of an error. Default behavior is disabled
+func WithErrorStatusEnabled() Options {
 	return func(h *hook) {
-		h.setErrorStatus = false
+		h.setErrorStatus = true
 	}
 }
 

--- a/hooks/open-telemetry/pkg/otel.go
+++ b/hooks/open-telemetry/pkg/otel.go
@@ -17,12 +17,21 @@ const (
 )
 
 type hook struct {
+	setErrorStatus bool
 	openfeature.UnimplementedHook
 }
 
 // NewHook return a reference to a new instance of the OpenTelemetry Hook
-func NewHook() *hook {
-	return &hook{}
+func NewHook(opts ...Options) *hook {
+	h := &hook{
+		setErrorStatus: true,
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	return h
 }
 
 // After sets the feature_flag event and associated attributes on the span stored in the context
@@ -39,9 +48,24 @@ func (h *hook) After(ctx context.Context, hookContext openfeature.HookContext, f
 // Error records the given error against the span and sets the span to an error status
 func (h *hook) Error(ctx context.Context, hookContext openfeature.HookContext, err error, hookHints openfeature.HookHints) {
 	span := trace.SpanFromContext(ctx)
-	span.SetStatus(codes.Error,
-		fmt.Sprintf("error evaluating flag '%s' of type '%s'", hookContext.FlagKey(), hookContext.FlagType().String()))
+
+	if h.setErrorStatus {
+		span.SetStatus(codes.Error,
+			fmt.Sprintf("error evaluating flag '%s' of type '%s'", hookContext.FlagKey(), hookContext.FlagType().String()))
+	}
+
 	span.RecordError(err)
+}
+
+// Options of the hook
+
+type Options func(*hook)
+
+// WithErrorStatusDisabled prevents setting span status to codes.Error in case of an error. Default behavior is enabled
+func WithErrorStatusDisabled() Options {
+	return func(h *hook) {
+		h.setErrorStatus = false
+	}
 }
 
 var _ openfeature.Hook = &hook{}


### PR DESCRIPTION
## This PR

Fixes #208

This PR introduces hook build option `WithErrorStatusEnabled`. 

From README,

> **WithErrorStatusEnabled** : enable setting span status to `Error` in case of an error. Default behavior is disabled, 
  span status is unset for errors.

Code example

```
openfeature.AddHooks(
   otelhooks.NewHook(hooks.WithErrorStatusEnabled()))
```

This gives end-user the control over hook behavior
