### PR TITLE
feat: api change to support more usecases

### DIFF
--- a/hooks/open-telemetry/pkg/metrics.go
+++ b/hooks/open-telemetry/pkg/metrics.go
@@ -31,8 +31,15 @@ type MetricOptions func(*MetricsHook)
 
 // NewMetricsHook builds a metric hook backed by provided metric.Reader. Reader must be provided by developer and
 // its configurations govern metric exports
+// Deprecated: NewMetricsHook is deprecated. Please use NewMetricsHookFromProvider
 func NewMetricsHook(reader metric.Reader, opts ...MetricOptions) (*MetricsHook, error) {
 	provider := metric.NewMeterProvider(metric.WithReader(reader))
+
+	return NewMetricsHookForProvider(provider, opts...)
+}
+
+// NewMetricsHookForProvider builds a metric hook backed by metric.MeterProvider.
+func NewMetricsHookForProvider(provider *metric.MeterProvider, opts ...MetricOptions) (*MetricsHook, error) {
 	meter := provider.Meter(meterName)
 
 	activeCounter, err := meter.Int64UpDownCounter(evaluationActive, api.WithDescription("active flag evaluations counter"))

--- a/hooks/open-telemetry/pkg/metrics_test.go
+++ b/hooks/open-telemetry/pkg/metrics_test.go
@@ -21,7 +21,7 @@ func TestMetricsHook_BeforeStage(t *testing.T) {
 
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
-	metricsHook, err := NewMetricsHook(manualReader)
+	metricsHook, err := NewMetricsHookForProvider(metric.NewMeterProvider(metric.WithReader(manualReader)))
 	if err != nil {
 		t.Error(err)
 		return
@@ -72,7 +72,7 @@ func TestMetricsHook_AfterStage(t *testing.T) {
 	}
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
-	metricsHook, err := NewMetricsHook(manualReader)
+	metricsHook, err := NewMetricsHookForProvider(metric.NewMeterProvider(metric.WithReader(manualReader)))
 	if err != nil {
 		t.Error(err)
 		return
@@ -120,7 +120,7 @@ func TestMetricsHook_ErrorStage(t *testing.T) {
 	evalError := errors.New("some eval error")
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
-	metricsHook, err := NewMetricsHook(manualReader)
+	metricsHook, err := NewMetricsHookForProvider(metric.NewMeterProvider(metric.WithReader(manualReader)))
 	if err != nil {
 		t.Error(err)
 		return
@@ -173,7 +173,7 @@ func TestMetricsHook_FinallyStage(t *testing.T) {
 	hookContext := hookContext()
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
-	metricsHook, err := NewMetricsHook(manualReader)
+	metricsHook, err := NewMetricsHookForProvider(metric.NewMeterProvider(metric.WithReader(manualReader)))
 	if err != nil {
 		t.Error(err)
 		return
@@ -217,7 +217,7 @@ func TestMetricsHook_ActiveCounterShouldBeZero(t *testing.T) {
 	hookContext := hookContext()
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
-	metricsHook, err := NewMetricsHook(manualReader)
+	metricsHook, err := NewMetricsHookForProvider(metric.NewMeterProvider(metric.WithReader(manualReader)))
 	if err != nil {
 		t.Error(err)
 		return
@@ -323,7 +323,7 @@ func TestMetricHook_OptionMetadataDimensions(t *testing.T) {
 	}
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
-	metricsHook, err := NewMetricsHook(manualReader,
+	metricsHook, err := NewMetricsHookForProvider(metric.NewMeterProvider(metric.WithReader(manualReader)),
 		WithFlagMetadataDimensions(scopeDescription, stageDescription, scoreDescription, cachedDescription))
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
## This PR

Attempts to address https://github.com/open-feature/go-sdk-contrib/issues/243 

Depreacates `NewMetricsHook(reader metric.Reader)` and introduce `NewMetricsHookForProvider(provider *metric.MeterProvider)`. Non breaking change as we have not yet removed the API