### PR TITLE
fix: GitHub action dependency order for sbom gen

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,7 +4,7 @@ on:
       - main
 
 env:
-  DEFAULT_GO_VERSION: 1.19.3
+  DEFAULT_GO_VERSION: 1.18
 
 name: Run Release Please
 jobs:
@@ -33,17 +33,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      # Create SBOM
-      - name: Generate SBOM
-        uses: CycloneDX/gh-gomod-generate-sbom@v1
-        with:
-          version: v1
-          args: mod -licenses -json -output bom.json ${{ matrix.release }}
-      # Create licenses artifacts
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.18'
+      # Create SBOM
+      - name: Generate SBOM
+        uses: CycloneDX/gh-gomod-generate-sbom@v2
+        with:
+          version: v1
+          args: mod -licenses -json -output bom.json ${{ matrix.release }}
+      # Create licenses artifacts
       - name: Setup workspace
         run: make workspace-init
       - name: Install go-licenses

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
       # Create SBOM
       - name: Generate SBOM
-        uses: CycloneDX/gh-gomod-generate-sbom@v2
+        uses: CycloneDX/gh-gomod-generate-sbom@v1
         with:
           version: v1
           args: mod -licenses -json -output bom.json ${{ matrix.release }}
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: '1.18'
       - name: Setup workspace
         run: make workspace-init
       - name: Install go-licenses


### PR DESCRIPTION
## This PR

Attempts to fix recently seen release pipeline failures [1]. The failures started appearing after upgrading `CycloneDX/gh-gomod-generate-sbom`

PR attempts to fix this first by installing Go prior to `CycloneDX/gh-gomod-generate-sbom` 

Also adding quotes to go version in setup-go [2]


[1] - https://github.com/open-feature/go-sdk-contrib/actions/runs/5592620849/jobs/10225319674 
[2] - https://github.com/actions/setup-go#v3
