### PR TITLE
fix: lint correction on tests

### DIFF
--- a/providers/go-feature-flag/pkg/provider_module_test.go
+++ b/providers/go-feature-flag/pkg/provider_module_test.go
@@ -127,7 +127,9 @@ func TestProvider_module_BooleanEvaluation(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.BooleanValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -257,7 +259,9 @@ func TestProvider_module_StringEvaluation(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.StringValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -387,7 +391,9 @@ func TestProvider_module_FloatEvaluation(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.FloatValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -517,7 +523,9 @@ func TestProvider_module_IntEvaluation(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.IntValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -630,7 +638,9 @@ func TestProvider_module_ObjectEvaluation(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.ObjectValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 

--- a/providers/go-feature-flag/pkg/provider_test.go
+++ b/providers/go-feature-flag/pkg/provider_test.go
@@ -262,7 +262,9 @@ func TestProvider_BooleanEvaluation(t *testing.T) {
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.BooleanValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -389,7 +391,9 @@ func TestProvider_StringEvaluation(t *testing.T) {
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.StringValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -516,7 +520,9 @@ func TestProvider_FloatEvaluation(t *testing.T) {
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.FloatValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -643,7 +649,9 @@ func TestProvider_IntEvaluation(t *testing.T) {
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.IntValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -754,7 +762,9 @@ func TestProvider_ObjectEvaluation(t *testing.T) {
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
-			of.SetProvider(provider)
+
+			err = of.SetProvider(provider)
+			assert.NoError(t, err)
 			client := of.NewClient("test-app")
 			value, err := client.ObjectValueDetails(context.TODO(), tt.args.flag, tt.args.defaultValue, tt.args.evalCtx)
 
@@ -785,7 +795,9 @@ func TestProvider_Cache_Calling_Flag_Multiple_Time_Same_User(t *testing.T) {
 	provider, err := gofeatureflag.NewProvider(options)
 	defer provider.Shutdown()
 	assert.NoError(t, err)
-	of.SetProvider(provider)
+
+	err = of.SetProvider(provider)
+	assert.NoError(t, err)
 	client := of.NewClient("test-app")
 	got1, err := client.BooleanValueDetails(context.TODO(), "bool_targeting_match", false, defaultEvaluationCtx())
 	assert.NoError(t, err)
@@ -816,7 +828,9 @@ func TestProvider_Cache_Calling_Flag_Multiple_Time_Different_EvalutationCtx(t *t
 	provider, err := gofeatureflag.NewProvider(options)
 	defer provider.Shutdown()
 	assert.NoError(t, err)
-	of.SetProvider(provider)
+
+	err = of.SetProvider(provider)
+	assert.NoError(t, err)
 	client := of.NewClient("test-app")
 	ctx1 := of.NewEvaluationContext("ffbe55ca-2150-4f15-a842-af6efb3a1391", map[string]interface{}{})
 	ctx2 := of.NewEvaluationContext("316d4ac7-6072-472d-8a33-e35ed1702337", map[string]interface{}{})
@@ -851,7 +865,9 @@ func TestProvider_Cache_Fill_All_Cache(t *testing.T) {
 	provider, err := gofeatureflag.NewProvider(options)
 	defer provider.Shutdown()
 	assert.NoError(t, err)
-	of.SetProvider(provider)
+
+	err = of.SetProvider(provider)
+	assert.NoError(t, err)
 	client := of.NewClient("test-app")
 	ctx1 := of.NewEvaluationContext("ffbe55ca-2150-4f15-a842-af6efb3a1391", map[string]interface{}{})
 	ctx2 := of.NewEvaluationContext("316d4ac7-6072-472d-8a33-e35ed1702337", map[string]interface{}{})
@@ -883,7 +899,9 @@ func TestProvider_Cache_TTL_Reached(t *testing.T) {
 	provider, err := gofeatureflag.NewProvider(options)
 	defer provider.Shutdown()
 	assert.NoError(t, err)
-	of.SetProvider(provider)
+
+	err = of.SetProvider(provider)
+	assert.NoError(t, err)
 	client := of.NewClient("test-app")
 	_, err = client.BooleanValueDetails(context.TODO(), "bool_targeting_match", false, defaultEvaluationCtx())
 	assert.NoError(t, err)

--- a/providers/launchdarkly/example_test.go
+++ b/providers/launchdarkly/example_test.go
@@ -27,7 +27,10 @@ func Example() {
 	defer ldClient.Close()
 
 	// Set Launchdarkly as OpenFeature provider
-	openfeature.SetProvider(ofld.NewProvider(ldClient))
+	err = openfeature.SetProvider(ofld.NewProvider(ldClient))
+	if err != nil {
+		// handle error for provider initialization
+	}
 
 	// Set a multi-context evaluation context as example
 	evalCtx := openfeature.NewEvaluationContext("redpanda-12342", map[string]any{

--- a/providers/launchdarkly/pkg/provider_test.go
+++ b/providers/launchdarkly/pkg/provider_test.go
@@ -154,10 +154,11 @@ func TestContextEvaluation(t *testing.T) {
 		},
 	}
 
-	openfeature.SetProvider(NewProvider(
+	err := openfeature.SetProvider(NewProvider(
 		makeLDClient(t, "testdata/flags.json"),
 		WithLogger(newTestLogger(t)),
 	))
+	assert.Ok(t, err)
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -171,10 +172,11 @@ func TestContextEvaluation(t *testing.T) {
 }
 
 func TestStringEvaluation(t *testing.T) {
-	openfeature.SetProvider(NewProvider(
+	err := openfeature.SetProvider(NewProvider(
 		makeLDClient(t, "testdata/flags.json"),
 		WithLogger(newTestLogger(t)),
 	))
+	assert.Ok(t, err)
 
 	evalCtx := openfeature.NewEvaluationContext("blah1234", map[string]any{
 		"kind":            "organization-id",
@@ -191,10 +193,11 @@ func TestStringEvaluation(t *testing.T) {
 }
 
 func TestFloatEvaluation(t *testing.T) {
-	openfeature.SetProvider(NewProvider(
+	err := openfeature.SetProvider(NewProvider(
 		makeLDClient(t, "testdata/flags.json"),
 		WithLogger(newTestLogger(t)),
 	))
+	assert.Ok(t, err)
 
 	evalCtx := openfeature.NewEvaluationContext("blah1234", map[string]any{
 		"kind":            "organization-id",
@@ -211,10 +214,11 @@ func TestFloatEvaluation(t *testing.T) {
 }
 
 func TestIntEvaluation(t *testing.T) {
-	openfeature.SetProvider(NewProvider(
+	err := openfeature.SetProvider(NewProvider(
 		makeLDClient(t, "testdata/flags.json"),
 		WithLogger(newTestLogger(t)),
 	))
+	assert.Ok(t, err)
 
 	evalCtx := openfeature.NewEvaluationContext("blah1234", map[string]any{
 		"kind":            "organization-id",
@@ -231,10 +235,11 @@ func TestIntEvaluation(t *testing.T) {
 }
 
 func TestObjectEvaluation(t *testing.T) {
-	openfeature.SetProvider(NewProvider(
+	err := openfeature.SetProvider(NewProvider(
 		makeLDClient(t, "testdata/flags.json"),
 		WithLogger(newTestLogger(t)),
 	))
+	assert.Ok(t, err)
 
 	evalCtx := openfeature.NewEvaluationContext("redpanda-blah12342", map[string]any{
 		"kind":            "redpanda-id",
@@ -255,10 +260,11 @@ func TestObjectEvaluation(t *testing.T) {
 }
 
 func TestContextCancellation(t *testing.T) {
-	openfeature.SetProvider(NewProvider(
+	err := openfeature.SetProvider(NewProvider(
 		makeLDClient(t, "testdata/flags.json"),
 		WithLogger(newTestLogger(t)),
 	))
+	assert.Ok(t, err)
 
 	evalCtx := openfeature.NewEvaluationContext("redpanda-blah12342", map[string]any{
 		"kind":            "redpanda-id",
@@ -271,6 +277,6 @@ func TestContextCancellation(t *testing.T) {
 	client := openfeature.NewClient("objectEvalTests")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := client.ObjectValue(ctx, "rate_limit_config", nil, evalCtx)
+	_, err = client.ObjectValue(ctx, "rate_limit_config", nil, evalCtx)
 	assert.Equals(t, errors.New("GENERAL: context canceled"), errors.Unwrap(err))
 }

--- a/tests/flagd/pkg/integration/caching.go
+++ b/tests/flagd/pkg/integration/caching.go
@@ -313,7 +313,12 @@ func aProviderIsRegisteredWithCacheEnabled(ctx context.Context) (context.Context
 	pOptions := []flagd.ProviderOption{flagd.WithPort(8013)}
 	pOptions = append(pOptions, providerOptions...)
 	provider := flagd.NewProvider(pOptions...)
-	openfeature.SetProvider(provider)
+
+	err := openfeature.SetProvider(provider)
+	if err != nil {
+		return nil, err
+	}
+
 	client := openfeature.NewClient("caching tests")
 
 	select {

--- a/tests/flagd/pkg/integration/evaluation.go
+++ b/tests/flagd/pkg/integration/evaluation.go
@@ -659,7 +659,12 @@ func aProviderIsRegisteredWithCacheDisabled(ctx context.Context) (context.Contex
 	pOptions := []flagd.ProviderOption{flagd.WithPort(8013), flagd.WithoutCache()}
 	pOptions = append(pOptions, providerOptions...)
 	provider := flagd.NewProvider(pOptions...)
-	openfeature.SetProvider(provider)
+
+	err := openfeature.SetProvider(provider)
+	if err != nil {
+		return nil, err
+	}
+
 	client := openfeature.NewClient("evaluation tests")
 
 	select {


### PR DESCRIPTION
## This PR

Fixes lint issues resulting from Go-SDK 1.5.x update

Change - `SetProvider(provider)` vs `SetProvider(provider) error`