### PR TITLE
fix: go-feature-flag sdk - cache key

### DIFF
--- a/providers/go-feature-flag/pkg/model/eval_request.go
+++ b/providers/go-feature-flag/pkg/model/eval_request.go
@@ -39,6 +39,7 @@ func NewEvalFlagRequest[T JsonType](flatCtx of.FlattenedContext, defaultValue T)
 
 type EvalFlagRequest struct {
 	// User The representation of a user for your feature flag system.
+	// Deprecated: User please use EvaluationContext instead
 	User *UserRequest `json:"user" xml:"user" form:"user" query:"user"`
 	// EvaluationContext the context to evaluate the flag.
 	EvaluationContext *EvaluationContextRequest `json:"evaluationContext,omitempty" xml:"evaluationContext,omitempty" form:"evaluationContext,omitempty" query:"evaluationContext,omitempty"`

--- a/providers/go-feature-flag/pkg/provider.go
+++ b/providers/go-feature-flag/pkg/provider.go
@@ -317,7 +317,7 @@ func convertCache[T model.JsonType](value interface{}) (model.GenericResolutionD
 
 // evaluateWithRelayProxy is calling GO Feature Flag relay proxy to evaluate the file.
 func evaluateWithRelayProxy[T model.JsonType](provider *Provider, ctx context.Context, goffRequestBody model.EvalFlagRequest, flagName string, defaultValue T) model.GenericResolutionDetail[T] {
-	cacheKey := fmt.Sprintf("%s-%+v", flagName, goffRequestBody.User)
+	cacheKey := fmt.Sprintf("%s-%+v", flagName, goffRequestBody.EvaluationContext)
 	// check if flag is available in the cache
 	cacheResInterface, err := provider.cache.Get(cacheKey)
 	if err == nil {

--- a/providers/go-feature-flag/pkg/provider.go
+++ b/providers/go-feature-flag/pkg/provider.go
@@ -317,7 +317,7 @@ func convertCache[T model.JsonType](value interface{}) (model.GenericResolutionD
 
 // evaluateWithRelayProxy is calling GO Feature Flag relay proxy to evaluate the file.
 func evaluateWithRelayProxy[T model.JsonType](provider *Provider, ctx context.Context, goffRequestBody model.EvalFlagRequest, flagName string, defaultValue T) model.GenericResolutionDetail[T] {
-	cacheKey := fmt.Sprintf("%s-%s", flagName, goffRequestBody.User.Key)
+	cacheKey := fmt.Sprintf("%s-%+v", flagName, goffRequestBody.User)
 	// check if flag is available in the cache
 	cacheResInterface, err := provider.cache.Get(cacheKey)
 	if err == nil {


### PR DESCRIPTION
Problem:
Flag evaluation for same flag using different evaluation context properties can lead to cache key collision.
Solution:
Build cache key considering flag and user evaluation context properties.

### Related Issues
[java-sdk PR 369](https://github.com/open-feature/java-sdk-contrib/pull/369)

### How to test
Run unit tests.
Can test via go-feature-flag instance, while observing logs.
