### PR TITLE
feat!: attribute setter callbacks for otel hooks and remove deprecated constructors 

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -6,7 +6,7 @@
 
 ## Usage
 
-## Metric hook
+## Metrics hook
 
 This hook performs metric collection by tapping into various hook stages. Given below are the metrics are extracted by this hook,
 
@@ -15,33 +15,14 @@ This hook performs metric collection by tapping into various hook stages. Given 
 - `feature_flag.evaluation_error_total`
 - `feature_flag.evaluation_active_count`
 
-### Options
-
-#### WithFlagMetadataDimensions 
-
-This constructor option allows to configure dimension descriptions to be extracted from `openfeature.FlagMetadata`. 
-If present, these dimension will be added to the `feature_flag.evaluation_success_total` metric. 
-Missing metadata keys will be ignored by the implementation.
-
-Example usage,
+Consider example below for usage,
 
 ```go
-NewMetricsHook(reader,
-    WithFlagMetadataDimensions(
-        DimensionDescription{
-            Key:  "scope",
-            Type: String,
-        }))
-```
-
-### Example
-
-```go
-// Reader must be configured and injected based from application level
-var reader metric.Reader
+// provider must be configured and provided to constructor based on application configurations
+var provider *metric.MeterProvider
         
 // Derive metric hook from reader
-metricsHook, _ := hooks.NewMetricsHook(reader)
+metricsHook, _ := hooks.NewMetricsHookForProvider(provider)
 if err != nil {
     return err
 }
@@ -50,124 +31,76 @@ if err != nil {
 openfeature.AddHooks(metricsHook)
 ```
 
-## Span hook
+### Options
 
-For this hook to function correctly a global `TracerProvider` must be set, an example of how to do this can be found below.
+#### WithMetricsAttributeSetter
 
-The `open telemetry hook` taps into the after and error methods of the hook lifecycle to write `events` and `attributes`to an existing `span`.
-A `context.Context` containing a `span` must be passed to the client evaluation method, otherwise the hook will no-op.
+This constructor options allows to provide a custom callback to extract dimensions from `FlagMetadata`.
+These attributes are added at the `After` stage of the hook.
+
+```go
+
+NewMetricsHookForProvider(provider,
+    WithMetricsAttributeSetter(
+    func(metadata openfeature.FlagMetadata) []attribute.KeyValue {
+		// custom attribute extraction logic
+		
+        return attributes
+    }))
+```
+
+#### WithFlagMetadataDimensions 
+
+This constructor option allows to configure dimension descriptions to be extracted from `openfeature.FlagMetadata`. 
+If present, these dimension will be added to the `feature_flag.evaluation_success_total` metric. 
+Missing metadata keys will be ignored by the implementation.
+
+```go
+NewMetricsHook(MeterProvider,
+    WithFlagMetadataDimensions(
+        DimensionDescription{
+            Key:  "scope",
+            Type: String,
+        }))
+```
+
+## Traces hook
+
+The traces hook taps into the after and error methods of the hook lifecycle to write `events` and `attributes`to an existing `span`.
+A `context.Context` containing a `span` must be passed to the client evaluation method, otherwise the hook will be no-op.
+
+```go
+
+// Register traces hook
+openfeature.AddHooks(hooks.NewTracesHook())
+client := openfeature.NewClient("methodA")
+
+// Initialize otel span
+spanCtx, span := tracer.Start(context.Background(), "myBoolFlag")
+client.BooleanValueDetails(spanCtx, "myBoolFlag", false, openfeature.EvaluationContext{})
+
+...
+
+span.End()
+```
 
 ### Options
 
-- WithErrorStatusEnabled: enable setting span status to `Error` in case of an error. Default behavior is disabled, 
-  span status is unset for errors.
+### WithErrorStatusEnabled
 
-### Example
+Enable setting span status to `Error` in case of an error. Default behavior is disabled, span status is unset for errors.
 
-The following example demonstrates the use of the `OpenTelemetry hook` with the `OpenFeature go-sdk`.
-The traces are sent to a `zipkin` server running at `:9411` which will receive the following trace:
+### WithTracesAttributeSetter
 
-```json
-{
-  "traceId": "ac4464e6387c552b4b55ab3d19bf64f9",
-  "id": "f677ca41dbfd6bfe",
-  "name": "run",
-  "timestamp": 1673431556236064,
-  "duration": 45,
-  "localEndpoint": {
-    "serviceName": "hook-example"
-  },
-  "annotations": [
-    {
-      "timestamp": 1673431556236107,
-      "value": "feature_flag: {\"feature_flag.key\":\"my-bool-flag\",\"feature_flag.provider_name\":\"NoopProvider\",\"feature_flag.variant\":\"default-variant\"}"
-    }
-  ],
-  "tags": {
-    "otel.library.name": "test-tracer",
-    "service.name": "hook-example"
-  }
-}
-```
+This constructor options allows to provide a custom callback to extract dimensions from `FlagMetadata`.
+These attributes are added at the `After` stage of the hook.
 
 ```go
-package main
 
-import (
-	"context"
-	"flag"
-	"log"
-	"os"
-	"os/signal"
-
-	otelHook "github.com/open-feature/go-sdk-contrib/hooks/open-telemetry/pkg"
-
-	"github.com/open-feature/go-sdk/pkg/openfeature"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/zipkin"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
-)
-
-var logger = log.New(os.Stderr, "hook-example", log.Ldate|log.Ltime|log.Llongfile)
-
-// initTracer creates a new trace provider instance and registers it as global trace provider.
-func initTracer(url string) (func(context.Context) error, error) {
-	exporter, err := zipkin.New(
-		url,
-		zipkin.WithLogger(logger),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	batcher := sdktrace.NewBatchSpanProcessor(exporter)
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSpanProcessor(batcher),
-		sdktrace.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("hook-example"),
-		)),
-	)
-	otel.SetTracerProvider(tp)
-
-	return tp.Shutdown, nil
-}
-
-func main() {
-	url := flag.String("zipkin", "http://localhost:9411/api/v2/spans", "zipkin url")
-	flag.Parse()
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
-
-	shutdown, err := initTracer(*url)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func() {
-		if err := shutdown(ctx); err != nil {
-			log.Fatalf("failed to shutdown TracerProvider: %w", err)
-		}
-	}()
-
-	// set up the span
-	ctx, s := otel.Tracer("test-tracer").Start(ctx, "run")
-	// set the opentelemetry hook
-	openfeature.AddHooks(otelHook.NewHook())
-	// create a new client
-	client := openfeature.NewClient("test-client")
-	// evaluate a flag value
-	client.ObjectValueDetails(
-		ctx,
-		"my-bool-flag",
-		map[string]interface{}{
-			"foo": "bar",
-		},
-		openfeature.EvaluationContext{},
-	)
-	s.End()
-}
+NewTracesHook(WithMetricsAttributeSetter(
+    func(metadata openfeature.FlagMetadata) []attribute.KeyValue {
+		// custom attribute extraction logic
+		
+        return attributes
+    }))
 ```

--- a/hooks/open-telemetry/pkg/common_test.go
+++ b/hooks/open-telemetry/pkg/common_test.go
@@ -1,0 +1,76 @@
+package otel
+
+import (
+	"github.com/open-feature/go-sdk/pkg/openfeature"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// test commons
+
+var scopeKey = "scope"
+var scopeValue = "7c34165e-fbef-11ed-be56-0242ac120002"
+var scopeDescription = DimensionDescription{
+	Key:  scopeKey,
+	Type: String,
+}
+
+var stageKey = "stage"
+var stageValue = 1
+var stageDescription = DimensionDescription{
+	Key:  stageKey,
+	Type: Int,
+}
+
+var scoreKey = "score"
+var scoreValue = 4.5
+var scoreDescription = DimensionDescription{
+	Key:  scoreKey,
+	Type: Float,
+}
+
+var cachedKey = "cached"
+var cacheValue = false
+var cachedDescription = DimensionDescription{
+	Key:  cachedKey,
+	Type: Bool,
+}
+
+var evalMetadata = map[string]interface{}{
+	scopeKey:  scopeValue,
+	stageKey:  stageValue,
+	scoreKey:  scoreValue,
+	cachedKey: cacheValue,
+}
+
+var extractionCallback = func(metadata openfeature.FlagMetadata) []attribute.KeyValue {
+	attribs := []attribute.KeyValue{}
+
+	scope, err := metadata.GetString(scopeKey)
+	if err != nil {
+		panic(err)
+	}
+
+	attribs = append(attribs, attribute.String(scopeKey, scope))
+
+	stage, err := metadata.GetInt(stageKey)
+	if err != nil {
+		panic(err)
+	}
+
+	attribs = append(attribs, attribute.Int64(stageKey, stage))
+
+	score, err := metadata.GetFloat(scoreKey)
+	if err != nil {
+		panic(err)
+	}
+
+	attribs = append(attribs, attribute.Float64(scoreKey, score))
+
+	cached, err := metadata.GetBool(cachedKey)
+	if err != nil {
+		panic(err)
+	}
+
+	attribs = append(attribs, attribute.Bool(cachedKey, cached))
+	return attribs
+}

--- a/hooks/open-telemetry/pkg/metrics.go
+++ b/hooks/open-telemetry/pkg/metrics.go
@@ -25,7 +25,7 @@ type MetricsHook struct {
 	errorCounter   api.Int64Counter
 
 	flagEvalMetadataDimensions []DimensionDescription
-	attributeSetterCallback    *func(openfeature.FlagMetadata) []attribute.KeyValue
+	attributeMapperCallback    *func(openfeature.FlagMetadata) []attribute.KeyValue
 }
 
 var _ openfeature.Hook = &MetricsHook{}
@@ -98,8 +98,8 @@ func (h *MetricsHook) After(ctx context.Context, hCtx openfeature.HookContext,
 	fromMetadata := descriptionsToAttributes(details.FlagMetadata, h.flagEvalMetadataDimensions)
 	attribs = append(attribs, fromMetadata...)
 
-	if h.attributeSetterCallback != nil {
-		attribs = append(attribs, (*h.attributeSetterCallback)(details.FlagMetadata)...)
+	if h.attributeMapperCallback != nil {
+		attribs = append(attribs, (*h.attributeMapperCallback)(details.FlagMetadata)...)
 	}
 
 	h.successCounter.Add(ctx, 1, api.WithAttributes(attribs...))
@@ -149,11 +149,11 @@ func WithFlagMetadataDimensions(descriptions ...DimensionDescription) MetricOpti
 	}
 }
 
-// WithAttributeSetterForMetrics allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
+// WithMetricsAttributeSetter allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
 // []attribute.KeyValue derived from those metadata.
-func WithAttributeSetterForMetrics(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) MetricOptions {
+func WithMetricsAttributeSetter(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) MetricOptions {
 	return func(metricsHook *MetricsHook) {
-		metricsHook.attributeSetterCallback = callback
+		metricsHook.attributeMapperCallback = callback
 	}
 }
 

--- a/hooks/open-telemetry/pkg/metrics.go
+++ b/hooks/open-telemetry/pkg/metrics.go
@@ -25,18 +25,10 @@ type MetricsHook struct {
 	errorCounter   api.Int64Counter
 
 	flagEvalMetadataDimensions []DimensionDescription
+	attributeSetterCallback    *func(openfeature.FlagMetadata) []attribute.KeyValue
 }
 
-type MetricOptions func(*MetricsHook)
-
-// NewMetricsHook builds a metric hook backed by provided metric.Reader. Reader must be provided by developer and
-// its configurations govern metric exports
-// Deprecated: NewMetricsHook is deprecated. Please use NewMetricsHookFromProvider
-func NewMetricsHook(reader metric.Reader, opts ...MetricOptions) (*MetricsHook, error) {
-	provider := metric.NewMeterProvider(metric.WithReader(reader))
-
-	return NewMetricsHookForProvider(provider, opts...)
-}
+var _ openfeature.Hook = &MetricsHook{}
 
 // NewMetricsHookForProvider builds a metric hook backed by metric.MeterProvider.
 func NewMetricsHookForProvider(provider *metric.MeterProvider, opts ...MetricOptions) (*MetricsHook, error) {
@@ -104,8 +96,12 @@ func (h *MetricsHook) After(ctx context.Context, hCtx openfeature.HookContext,
 		attribs = append(attribs, attribute.String("reason", string(details.Reason)))
 	}
 	fromMetadata := descriptionsToAttributes(details.FlagMetadata, h.flagEvalMetadataDimensions)
-
 	attribs = append(attribs, fromMetadata...)
+
+	if h.attributeSetterCallback != nil {
+		attribs = append(attribs, (*h.attributeSetterCallback)(details.FlagMetadata)...)
+	}
+
 	h.successCounter.Add(ctx, 1, api.WithAttributes(attribs...))
 
 	return nil
@@ -135,6 +131,10 @@ const (
 	Float
 )
 
+// Options of the hook
+
+type MetricOptions func(*MetricsHook)
+
 // DimensionDescription is key and Type description of the dimension
 type DimensionDescription struct {
 	Key string
@@ -146,6 +146,14 @@ type DimensionDescription struct {
 func WithFlagMetadataDimensions(descriptions ...DimensionDescription) MetricOptions {
 	return func(metricsHook *MetricsHook) {
 		metricsHook.flagEvalMetadataDimensions = descriptions
+	}
+}
+
+// WithAttributeSetterForMetrics allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
+// []attribute.KeyValue derived from those metadata.
+func WithAttributeSetterForMetrics(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) MetricOptions {
+	return func(metricsHook *MetricsHook) {
+		metricsHook.attributeSetterCallback = callback
 	}
 }
 

--- a/hooks/open-telemetry/pkg/metrics.go
+++ b/hooks/open-telemetry/pkg/metrics.go
@@ -25,7 +25,7 @@ type MetricsHook struct {
 	errorCounter   api.Int64Counter
 
 	flagEvalMetadataDimensions []DimensionDescription
-	attributeMapperCallback    *func(openfeature.FlagMetadata) []attribute.KeyValue
+	attributeMapperCallback    func(openfeature.FlagMetadata) []attribute.KeyValue
 }
 
 var _ openfeature.Hook = &MetricsHook{}
@@ -99,7 +99,7 @@ func (h *MetricsHook) After(ctx context.Context, hCtx openfeature.HookContext,
 	attribs = append(attribs, fromMetadata...)
 
 	if h.attributeMapperCallback != nil {
-		attribs = append(attribs, (*h.attributeMapperCallback)(details.FlagMetadata)...)
+		attribs = append(attribs, h.attributeMapperCallback(details.FlagMetadata)...)
 	}
 
 	h.successCounter.Add(ctx, 1, api.WithAttributes(attribs...))
@@ -151,7 +151,7 @@ func WithFlagMetadataDimensions(descriptions ...DimensionDescription) MetricOpti
 
 // WithMetricsAttributeSetter allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
 // []attribute.KeyValue derived from those metadata.
-func WithMetricsAttributeSetter(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) MetricOptions {
+func WithMetricsAttributeSetter(callback func(openfeature.FlagMetadata) []attribute.KeyValue) MetricOptions {
 	return func(metricsHook *MetricsHook) {
 		metricsHook.attributeMapperCallback = callback
 	}

--- a/hooks/open-telemetry/pkg/metrics_test.go
+++ b/hooks/open-telemetry/pkg/metrics_test.go
@@ -363,7 +363,7 @@ func TestMetricHook_MetadataExtractionOptions(t *testing.T) {
 		// when
 		metricsHook, err := NewMetricsHookForProvider(
 			metric.NewMeterProvider(metric.WithReader(manualReader)),
-			WithMetricsAttributeSetter(&extractionCallback))
+			WithMetricsAttributeSetter(extractionCallback))
 		if err != nil {
 			t.Error(err)
 			return

--- a/hooks/open-telemetry/pkg/metrics_test.go
+++ b/hooks/open-telemetry/pkg/metrics_test.go
@@ -363,7 +363,7 @@ func TestMetricHook_MetadataExtractionOptions(t *testing.T) {
 		// when
 		metricsHook, err := NewMetricsHookForProvider(
 			metric.NewMeterProvider(metric.WithReader(manualReader)),
-			WithAttributeSetterForMetrics(&extractionCallback))
+			WithMetricsAttributeSetter(&extractionCallback))
 		if err != nil {
 			t.Error(err)
 			return

--- a/hooks/open-telemetry/pkg/traces.go
+++ b/hooks/open-telemetry/pkg/traces.go
@@ -20,7 +20,7 @@ const (
 // traceHook is the hook implementation for OTel traces
 type traceHook struct {
 	setErrorStatus          bool
-	attributeSetterCallback *func(openfeature.FlagMetadata) []attribute.KeyValue
+	attributeMapperCallback *func(openfeature.FlagMetadata) []attribute.KeyValue
 
 	openfeature.UnimplementedHook
 }
@@ -48,8 +48,8 @@ func (h *traceHook) After(ctx context.Context, hookContext openfeature.HookConte
 		attribs = append(attribs, semconv.FeatureFlagVariant(flagEvaluationDetails.Variant))
 	}
 
-	if h.attributeSetterCallback != nil {
-		attribs = append(attribs, (*h.attributeSetterCallback)(flagEvaluationDetails.FlagMetadata)...)
+	if h.attributeMapperCallback != nil {
+		attribs = append(attribs, (*h.attributeMapperCallback)(flagEvaluationDetails.FlagMetadata)...)
 	}
 
 	span := trace.SpanFromContext(ctx)
@@ -83,11 +83,11 @@ func WithErrorStatusEnabled() Options {
 	}
 }
 
-// WithAttributeSetterForTraces allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
+// WithTracesAttributeSetter allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
 // []attribute.KeyValue derived from those metadata.
 // If present, returned attributes will be added to successful evaluation traces
-func WithAttributeSetterForTraces(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) Options {
+func WithTracesAttributeSetter(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) Options {
 	return func(tracesHook *traceHook) {
-		tracesHook.attributeSetterCallback = callback
+		tracesHook.attributeMapperCallback = callback
 	}
 }

--- a/hooks/open-telemetry/pkg/traces.go
+++ b/hooks/open-telemetry/pkg/traces.go
@@ -20,7 +20,7 @@ const (
 // traceHook is the hook implementation for OTel traces
 type traceHook struct {
 	setErrorStatus          bool
-	attributeMapperCallback *func(openfeature.FlagMetadata) []attribute.KeyValue
+	attributeMapperCallback func(openfeature.FlagMetadata) []attribute.KeyValue
 
 	openfeature.UnimplementedHook
 }
@@ -49,7 +49,7 @@ func (h *traceHook) After(ctx context.Context, hookContext openfeature.HookConte
 	}
 
 	if h.attributeMapperCallback != nil {
-		attribs = append(attribs, (*h.attributeMapperCallback)(flagEvaluationDetails.FlagMetadata)...)
+		attribs = append(attribs, h.attributeMapperCallback(flagEvaluationDetails.FlagMetadata)...)
 	}
 
 	span := trace.SpanFromContext(ctx)
@@ -86,7 +86,7 @@ func WithErrorStatusEnabled() Options {
 // WithTracesAttributeSetter allows to set a extractionCallback which accept openfeature.FlagMetadata and returns
 // []attribute.KeyValue derived from those metadata.
 // If present, returned attributes will be added to successful evaluation traces
-func WithTracesAttributeSetter(callback *func(openfeature.FlagMetadata) []attribute.KeyValue) Options {
+func WithTracesAttributeSetter(callback func(openfeature.FlagMetadata) []attribute.KeyValue) Options {
 	return func(tracesHook *traceHook) {
 		tracesHook.attributeMapperCallback = callback
 	}

--- a/hooks/open-telemetry/pkg/traces_test.go
+++ b/hooks/open-telemetry/pkg/traces_test.go
@@ -207,7 +207,7 @@ func TestTracesHook_MedataExtractionOption(t *testing.T) {
 		},
 	}
 
-	hook := NewTracesHook(WithTracesAttributeSetter(&extractionCallback))
+	hook := NewTracesHook(WithTracesAttributeSetter(extractionCallback))
 
 	// when
 	ctx, span := otel.Tracer("test-tracer").Start(context.Background(), "Run")

--- a/hooks/open-telemetry/pkg/traces_test.go
+++ b/hooks/open-telemetry/pkg/traces_test.go
@@ -207,7 +207,7 @@ func TestTracesHook_MedataExtractionOption(t *testing.T) {
 		},
 	}
 
-	hook := NewTracesHook(WithAttributeSetterForTraces(&extractionCallback))
+	hook := NewTracesHook(WithTracesAttributeSetter(&extractionCallback))
 
 	// when
 	ctx, span := otel.Tracer("test-tracer").Start(context.Background(), "Run")


### PR DESCRIPTION
## This PR

FIxes #294

Adds new OTel hook constructor options for `TraceHook` & `MetricsHooks`

New options `WithAttributeSetterForTraces` & `WithAttributeSetterForMetrics` allow the registration of custom callbacks to extract OTel attributes (dimensions) from flag evaluation metadata 

Callback has the following signature,

```Go
func(openfeature.FlagMetadata) []attribute.KeyValue
```

Along with this change, I have removed deprecated constructors to fascilitate easy future enahancements 

