### PR TITLE
chore: add flagd e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,12 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      # flagd-testbed for flagd-provider e2e tests
+      flagd:
+        image: ghcr.io/open-feature/flagd-testbed:latest
+        ports:
+          - 8013:8013
     steps:
       - name: Install Go
         uses: actions/setup-go@v4
@@ -50,6 +56,8 @@ jobs:
           go-version: ${{ env.DEFAULT_GO_VERSION }}
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Setup Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -63,5 +71,5 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
       - name: Run workspace init
         run: make workspace-init
-      - name: Run tests
-        run: make test
+      - name: Run tests, including e2e
+        run: make e2e

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec"]
+	path = spec
+	url = https://github.com/open-feature/spec

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ workspace-update:
 test:
 	go list -f '{{.Dir}}/...' -m | xargs -I{} go test -v {}
 
+e2e:
+	go clean -testcache && go list -f '{{.Dir}}/...' -m | xargs -I{} go test -tags=e2e -v {}
+
 lint: 
 	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
 	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run --deadline=3m --timeout=3m $(module)/...;)

--- a/providers/flagd/e2e/evaluation_test.go
+++ b/providers/flagd/e2e/evaluation_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/cucumber/godog"
+	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
+	"github.com/open-feature/go-sdk-contrib/tests/flagd/pkg/integration"
+)
+
+func TestEvaluation(t *testing.T) {
+	if testing.Short() {
+		// skip e2e if testing -short
+		t.Skip()
+	}
+
+	flag.Parse()
+
+	var providerOptions []flagd.ProviderOption
+	name := "evaluation.feature"
+
+	testSuite := godog.TestSuite{
+		Name:                name,
+		ScenarioInitializer: integration.InitializeEvaluationScenario(providerOptions...),
+		Options: &godog.Options{
+			Format:   "pretty",
+			Paths:    []string{"../../../spec/specification/assets/gherkin/evaluation.feature"},
+			TestingT: t, // Testing instance that will run subtests.
+			Strict:   true,
+		},
+	}
+
+	if testSuite.Run() != 0 {
+		t.Fatal("non-zero status returned, failed to run evaluation tests")
+	}
+}


### PR DESCRIPTION
* adds e2e framework to contribs (tests marked with `// +build e2e` at top of file will run with `make e2e`)
* adds standard `evaluation.feature` gherkin tests for flagd provider

gherkin tests for in-memory provider will come next.

See the tests running in the CI: https://github.com/open-feature/go-sdk-contrib/actions/runs/6188614191/job/16800993762?pr=331#step:8:311