### PR TITLE
feat: deprecate dedicated flagd in-process provider

### DIFF
--- a/providers/flagd-in-process/README.md
+++ b/providers/flagd-in-process/README.md
@@ -1,4 +1,8 @@
-# In-process Flagd Provider
+# DEPRECATED - In-process Flagd Provider 
+
+> [!IMPORTANT]
+> This provider is DEPRECATED and will be removed soon.
+> [flagd provider](../flagd/README.md) now supports in-process flag evaluation and it will be maintained as a single package.
 
 This provider implements parts of the functionality of [Flagd](https://github.com/open-feature/flagd), and follows its
 specification for [in-process providers](https://flagd.dev/reference/specifications/in-process-providers/).

--- a/providers/flagd-in-process/pkg/provider.go
+++ b/providers/flagd-in-process/pkg/provider.go
@@ -59,6 +59,7 @@ type connectionInfo struct {
 
 type connectionState int
 
+// DEPRECATED : Please use flagd with WithInProcessResolver option instead of this dedicated provider
 type Provider struct {
 	ctx                   context.Context
 	cancelFunc            context.CancelFunc
@@ -80,6 +81,7 @@ type ProviderConfiguration struct {
 
 type ProviderOption func(*Provider)
 
+// DEPRECATED : Please use flagd with WithInProcessResolver option instead of this dedicated provider
 func NewProvider(ctx context.Context, opts ...ProviderOption) *Provider {
 	ctx, cancel := context.WithCancel(ctx)
 	provider := &Provider{

--- a/providers/flagd-in-process/pkg/provider.go
+++ b/providers/flagd-in-process/pkg/provider.go
@@ -81,7 +81,7 @@ type ProviderConfiguration struct {
 
 type ProviderOption func(*Provider)
 
-// DEPRECATED : Please use flagd with WithInProcessResolver option instead of this dedicated provider
+// Deprecated : Please use flagd with WithInProcessResolver option instead of this dedicated provider
 func NewProvider(ctx context.Context, opts ...ProviderOption) *Provider {
 	ctx, cancel := context.WithCancel(ctx)
 	provider := &Provider{

--- a/providers/flagd-in-process/pkg/provider.go
+++ b/providers/flagd-in-process/pkg/provider.go
@@ -59,7 +59,7 @@ type connectionInfo struct {
 
 type connectionState int
 
-// DEPRECATED : Please use flagd with WithInProcessResolver option instead of this dedicated provider
+// Deprecated: Please use flagd with WithInProcessResolver option instead of this dedicated provider
 type Provider struct {
 	ctx                   context.Context
 	cancelFunc            context.CancelFunc


### PR DESCRIPTION
## This PR

Comples part of #393

Adds deprecation notice on flagd in-process provider package.