### PR TITLE
docs: flipt grpc example

### DIFF
--- a/providers/flipt/README.md
+++ b/providers/flipt/README.md
@@ -84,7 +84,7 @@ func (t Token) ClientToken() (string, error) {
 }
 
 provider := flipt.NewProvider(
-    flipt.WithAddress("grpc://localhost:9000"),
+    flipt.WithAddress("localhost:9000"),
     flipt.WithCertificatePath("/path/to/cert.pem"), // optional
     flipt.WithClientProvider(Token("a-client-token")), // optional
 )


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This fixes open-feature/go-sdk-contrib#397. As seen in the [service implementation](https://github.com/boyvinall/go-sdk-contrib/blob/b4c20b45617e86b6e06c5c5fa68d672ff3efcb9b/providers/flipt/pkg/service/transport/service.go#L152), the scheme is used for http/https or if GRPC then unix:// is used. But plain GRPC should not provide the scheme.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #397

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test

A demo app can be seen [here](https://github.com/boyvinall/flipt-demo).

