### PR TITLE
feat: flagd - make sure provider initialize only once

### DIFF
--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Provider struct {
+	initialized           bool
 	logger                logr.Logger
 	providerConfiguration *providerConfiguration
 	service               IService
@@ -73,7 +74,15 @@ func NewProvider(opts ...ProviderOption) *Provider {
 	return provider
 }
 
-func (p *Provider) Init(evaluationContext of.EvaluationContext) error {
+func (p *Provider) Init(_ of.EvaluationContext) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	// avoid reinitialization if initialized
+	if p.initialized {
+		return nil
+	}
+
 	err := p.service.Init()
 	if err != nil {
 		return err
@@ -86,6 +95,7 @@ func (p *Provider) Init(evaluationContext of.EvaluationContext) error {
 	}
 
 	p.status = of.ReadyState
+	p.initialized = true
 
 	// start event handling after the first ready event
 	go func() {
@@ -112,6 +122,10 @@ func (p *Provider) Status() of.State {
 }
 
 func (p *Provider) Shutdown() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.initialized = false
 	p.service.Shutdown()
 }
 

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -30,6 +30,7 @@ func NewProvider(opts ...ProviderOption) *Provider {
 	providerConfiguration := NewDefaultConfiguration(log)
 
 	provider := &Provider{
+		initialized:           false,
 		eventStream:           make(chan of.Event),
 		logger:                log,
 		providerConfiguration: providerConfiguration,


### PR DESCRIPTION
## This PR

Fixed https://github.com/open-feature/go-sdk-contrib/issues/417 by adding locks and validations to avoid provider reinitializations. This is done at provider level hence no changes necessary at service level. 

Added a test to validate the logic. 