### PR TITLE
feat: flagd offline in-process support with flags sources from file

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -42,19 +42,37 @@ openfeature.SetProvider(provider)
 
 In the above example, in-process handlers attempt to connect to a sync service on address `localhost:8013` to obtain [flag definitions](https://github.com/open-feature/schemas/blob/main/json/flagd-definitions.json).
 
+#### Offline mode
+
+In-process resolvers can also work in an offline mode.
+To enable this mode, you should provide a valid flag configuration file with the option `WithOfflineFilePath`.
+
+```go
+provider := flagd.NewProvider(
+        flagd.WithInProcessResolver(),
+        flagd.WithOfflineFilePath(OFFLINE_FLAG_PATH))
+openfeature.SetProvider(provider)
+```
+
+Provider will attempt to detect file changes but this is a best effort attempt as file system events are different from os to os.
+This mode is useful for local development, tests and offline applications.
+For a full-featured, production-ready file-based implementation, use the RPC evaluator in combination with the flagd standalone application, which can be configured to watch files for changes.
+
 ## Configuration options
 
 Configuration can be provided as constructor options or as environment variables, where constructor options having the highest precedence.
 
 | Option name                                              | Environment variable name      | Type & supported value      | Default   | Compatible resolver |
 |----------------------------------------------------------|--------------------------------|-----------------------------|-----------|---------------------|
-| WithHost                                                 | FLAGD_HOST                     | string                      | localhost | RPC & in-process    |
-| WithPort                                                 | FLAGD_PORT                     | number                      | 8013      | RPC & in-process    |
-| WithTLS                                                  | FLAGD_TLS                      | boolean                     | false     | RPC & in-process    |
-| WithSocketPath                                           | FLAGD_SOCKET_PATH              | string                      | ""        | RPC & in-process    |
-| WithCertificatePath                                      | FLAGD_SERVER_CERT_PATH         | string                      | ""        | RPC & in-process    |
-| WithLRUCache<br/>WithBasicInMemoryCache<br/>WithoutCache | FLAGD_CACHE                    | string (lru, mem, disabled) | lru       | RPC                 |
-| WithEventStreamConnectionMaxAttempts                     | FLAGD_MAX_EVENT_STREAM_RETRIES | int                         | 5         | RPC                 |
+| WithHost                                                 | FLAGD_HOST                     | string                      | localhost | rpc & in-process    |
+| WithPort                                                 | FLAGD_PORT                     | number                      | 8013      | rpc & in-process    |
+| WithTLS                                                  | FLAGD_TLS                      | boolean                     | false     | rpc & in-process    |
+| WithSocketPath                                           | FLAGD_SOCKET_PATH              | string                      | ""        | rpc & in-process    |
+| WithCertificatePath                                      | FLAGD_SERVER_CERT_PATH         | string                      | ""        | rpc & in-process    |
+| WithLRUCache<br/>WithBasicInMemoryCache<br/>WithoutCache | FLAGD_CACHE                    | string (lru, mem, disabled) | lru       | rpc                 |
+| WithEventStreamConnectionMaxAttempts                     | FLAGD_MAX_EVENT_STREAM_RETRIES | int                         | 5         | rpc                 |
+| WithEventStreamConnectionMaxAttempts                     | FLAGD_MAX_EVENT_STREAM_RETRIES | int                         | 5         | rpc                 |
+| WithOfflineFilePath                                      | FLAGD_OFFLINE_FLAG_SOURCE_PATH | string                      | ""        | in-process          |
 
 ### Overriding behavior
 

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -45,7 +45,7 @@ In the above example, in-process handlers attempt to connect to a sync service o
 #### Offline mode
 
 In-process resolvers can also work in an offline mode.
-To enable this mode, you should provide a valid flag configuration file with the option `WithOfflineFilePath`.
+To enable this mode, you should provide a [valid flag configuration](https://flagd.dev/reference/flag-definitions/) file with the option `WithOfflineFilePath`.
 
 ```go
 provider := flagd.NewProvider(

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -54,7 +54,7 @@ provider := flagd.NewProvider(
 openfeature.SetProvider(provider)
 ```
 
-Provider will attempt to detect file changes, but this is a best effort attempt as file system events are different between operating systems.
+The provider will attempt to detect file changes, but this is a best-effort attempt as file system events differ between operating systems.
 This mode is useful for local development, tests and offline applications.
 
 > [!IMPORTANT]

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -54,9 +54,12 @@ provider := flagd.NewProvider(
 openfeature.SetProvider(provider)
 ```
 
-Provider will attempt to detect file changes but this is a best effort attempt as file system events are different from os to os.
+Provider will attempt to detect file changes, but this is a best effort attempt as file system events are different between operating systems.
 This mode is useful for local development, tests and offline applications.
-For a full-featured, production-ready file-based implementation, use the RPC evaluator in combination with the flagd standalone application, which can be configured to watch files for changes.
+
+> [!IMPORTANT]
+> Note that you can only use a single flag source (either gRPC or offline file) for the in-process resolver. 
+> If both sources are configured, offline mode will be selected.
 
 ## Configuration options
 

--- a/providers/flagd/pkg/configuration.go
+++ b/providers/flagd/pkg/configuration.go
@@ -19,7 +19,6 @@ const (
 	defaultCache                      = cache.LRUValue
 	defaultHost                       = "localhost"
 	defaultResolver                   = rpc
-	defaultSourceSelector             = ""
 
 	rpc       ResolverType = "rpc"
 	inProcess ResolverType = "in-process"
@@ -34,6 +33,7 @@ const (
 	flagdMaxEventStreamRetriesEnvironmentVariableName = "FLAGD_MAX_EVENT_STREAM_RETRIES"
 	flagdResolverEnvironmentVariableName              = "FLAGD_RESOLVER"
 	flagdSourceSelectorEnvironmentVariableName        = "FLAGD_SOURCE_SELECTOR"
+	flagdOfflinePathEnvironmentVariableName           = "FLAGD_OFFLINE_FLAG_SOURCE_PATH"
 )
 
 type providerConfiguration struct {
@@ -42,6 +42,7 @@ type providerConfiguration struct {
 	EventStreamConnectionMaxAttempts int
 	Host                             string
 	MaxCacheSize                     int
+	OfflineFlagSourcePath            string
 	OtelIntercept                    bool
 	Port                             uint16
 	Resolver                         ResolverType
@@ -52,7 +53,7 @@ type providerConfiguration struct {
 	log logr.Logger
 }
 
-func NewDefaultConfiguration(log logr.Logger) *providerConfiguration {
+func newDefaultConfiguration(log logr.Logger) *providerConfiguration {
 	p := &providerConfiguration{
 		CacheType:                        defaultCache,
 		EventStreamConnectionMaxAttempts: defaultMaxEventStreamRetries,
@@ -148,6 +149,10 @@ func (cfg *providerConfiguration) updateFromEnvVar() {
 			cfg.log.Info("invalid resolver type: %s, falling back to default: %s", resolver, defaultResolver)
 			cfg.Resolver = defaultResolver
 		}
+	}
+
+	if offlinePath := os.Getenv(flagdOfflinePathEnvironmentVariableName); offlinePath != "" {
+		cfg.OfflineFlagSourcePath = offlinePath
 	}
 
 	if selector := os.Getenv(flagdSourceSelectorEnvironmentVariableName); selector != "" {

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -27,7 +27,7 @@ func NewProvider(opts ...ProviderOption) *Provider {
 	log := logr.New(logger.Logger{})
 
 	// initialize with default configurations
-	providerConfiguration := NewDefaultConfiguration(log)
+	providerConfiguration := newDefaultConfiguration(log)
 
 	provider := &Provider{
 		initialized:           false,
@@ -63,10 +63,11 @@ func NewProvider(opts ...ProviderOption) *Provider {
 			provider.providerConfiguration.EventStreamConnectionMaxAttempts)
 	} else {
 		service = process.NewInProcessService(process.Configuration{
-			Host:       provider.providerConfiguration.Host,
-			Port:       provider.providerConfiguration.Port,
-			Selector:   provider.providerConfiguration.Selector,
-			TLSEnabled: provider.providerConfiguration.TLSEnabled,
+			Host:              provider.providerConfiguration.Host,
+			Port:              provider.providerConfiguration.Port,
+			Selector:          provider.providerConfiguration.Selector,
+			TLSEnabled:        provider.providerConfiguration.TLSEnabled,
+			OfflineFlagSource: provider.providerConfiguration.OfflineFlagSourcePath,
 		})
 	}
 
@@ -283,6 +284,14 @@ func WithRPCResolver() ProviderOption {
 func WithInProcessResolver() ProviderOption {
 	return func(p *Provider) {
 		p.providerConfiguration.Resolver = inProcess
+	}
+}
+
+// WithOfflineFilePath file path to obtain flags to run provider in offline mode with in-process evaluations.
+// This is only useful with inProcess resolver type
+func WithOfflineFilePath(path string) ProviderOption {
+	return func(p *Provider) {
+		p.providerConfiguration.OfflineFlagSourcePath = path
 	}
 }
 

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -297,12 +297,7 @@ func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string
 	}
 
 	// grpc sync provider
-	var uri string
-	if cfg.TLSEnabled {
-		uri = fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	} else {
-		uri = fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	}
+	uri := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
 
 	return &grpc.Sync{
 		CredentialBuilder: &credentials.CredentialBuilder{},

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -289,6 +289,7 @@ func (i *InProcess) appendMetadata(evalMetadata map[string]interface{}) {
 func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string) {
 	if cfg.OfflineFlagSource != "" {
 		// file sync provider
+		log.Info("operating in in-process mode with offline flags sourced from " + cfg.OfflineFlagSource)
 		return &file.Sync{
 			URI:    cfg.OfflineFlagSource,
 			Logger: log,
@@ -298,6 +299,7 @@ func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string
 
 	// grpc sync provider
 	uri := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	log.Info("operating in in-process mode with flags sourced from " + uri)
 
 	return &grpc.Sync{
 		CredentialBuilder: &credentials.CredentialBuilder{},

--- a/providers/flagd/pkg/service/in_process/service_file_test.go
+++ b/providers/flagd/pkg/service/in_process/service_file_test.go
@@ -32,8 +32,8 @@ func TestInProcessOfflineMode(t *testing.T) {
 
 	select {
 	case event := <-channel:
-		if event.EventType == of.ProviderError {
-			t.Fatalf("Provider initialization failed, %s", event.Message)
+		if event.EventType != of.ProviderReady {
+			t.Fatalf("Provider initialization failed. Got event type %s with message %s", event.EventType, event.Message)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Provider initialization did not complete within acceptable timeframe ")

--- a/providers/flagd/pkg/service/in_process/service_file_test.go
+++ b/providers/flagd/pkg/service/in_process/service_file_test.go
@@ -1,0 +1,53 @@
+package process
+
+import (
+	"context"
+	of "github.com/open-feature/go-sdk/openfeature"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInProcessOfflineMode(t *testing.T) {
+	// given
+	flagFile := "config.json"
+	offlinePath := filepath.Join(t.TempDir(), flagFile)
+
+	err := os.WriteFile(offlinePath, []byte(flagRsp), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// when
+	service := NewInProcessService(Configuration{OfflineFlagSource: offlinePath})
+
+	err = service.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// then
+	channel := service.EventChannel()
+
+	select {
+	case event := <-channel:
+		if event.EventType == of.ProviderError {
+			t.Fatalf("Provider initialization failed, %s", event.Message)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Provider initialization did not complete within acceptable timeframe ")
+	}
+
+	// provider must evaluate flag from the grpc source data
+	detail := service.ResolveBoolean(context.Background(), "myBoolFlag", false, make(map[string]interface{}))
+
+	if !detail.Value {
+		t.Fatal("Expected true, but got false")
+	}
+
+	// check for metadata - scope from grpc sync
+	if len(detail.FlagMetadata) == 0 && detail.FlagMetadata["scope"] == "" {
+		t.Fatal("Expected scope to be present, but got none")
+	}
+}

--- a/providers/flagd/pkg/service/in_process/service_grpc_test.go
+++ b/providers/flagd/pkg/service/in_process/service_grpc_test.go
@@ -13,18 +13,8 @@ import (
 	"time"
 )
 
-func TestInProcessProviderEvaluation(t *testing.T) {
-	// given
-	host := "localhost"
-	port := 8090
-	scope := "app=myapp"
-
-	listen, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	flagRsp := `{
+// shared flag for tests
+var flagRsp = `{
 		"flags": {
 		  "myBoolFlag": {
 			"state": "ENABLED",
@@ -36,6 +26,17 @@ func TestInProcessProviderEvaluation(t *testing.T) {
 		  }
 		}
 	}`
+
+func TestInProcessProviderEvaluation(t *testing.T) {
+	// given
+	host := "localhost"
+	port := 8090
+	scope := "app=myapp"
+
+	listen, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	bufServ := &bufferedServer{
 		listener: listen,

--- a/providers/flagd/pkg/service/rpc/service.go
+++ b/providers/flagd/pkg/service/rpc/service.go
@@ -54,6 +54,7 @@ type Service struct {
 }
 
 func NewService(cfg Configuration, cache *cache.Service, logger logr.Logger, retries int) *Service {
+	logger.Info("operating in rpc mode with flags sourced from " + fmt.Sprintf("%s:%d", cfg.Host, cfg.Port))
 	return &Service{
 		cache:        cache,
 		cfg:          cfg,


### PR DESCRIPTION
## This PR

Fixes #375 and introduce offline in-process mode for flagd go provider 

Check the below code to see how you can construct the provider in this mode,

```go
provider := flagd.NewProvider(
        flagd.WithInProcessResolver(),
        flagd.WithOfflineFilePath(OFFLINE_FLAG_PATH))
openfeature.SetProvider(provider)
```

### Internals

This implementation use flagd file sync implementation [^1]. This minimize code duplications as well as allow us to reuse file watcher logic of flagd itself. 

[^1]: https://github.com/open-feature/flagd/tree/main/core/pkg/sync/file
