### PR TITLE
chore: bump testbed version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,12 +42,12 @@ jobs:
     services:
       # flagd-testbed for flagd-provider e2e tests
       flagd:
-        image: ghcr.io/open-feature/flagd-testbed:v0.4.10
+        image: ghcr.io/open-feature/flagd-testbed:v0.4.11
         ports:
           - 8013:8013
       # sync-testbed for flagd-provider e2e tests
       sync:
-        image: ghcr.io/open-feature/sync-testbed:v0.4.10
+        image: ghcr.io/open-feature/sync-testbed:v0.4.11
         ports:
           - 9090:9090
     steps:


### PR DESCRIPTION
## This PR

Bump testbed to release https://github.com/open-feature/flagd-testbed/releases/tag/v0.4.11 