### PR TITLE
chore(providers/flipt): update README with correct provider import statement

### DIFF
--- a/providers/flipt/README.md
+++ b/providers/flipt/README.md
@@ -27,7 +27,7 @@ package main
 import (
     "context"
 
-    "github.com/open-feature/go-sdk-contrib/providers/flipt"
+    flipt "github.com/open-feature/go-sdk-contrib/providers/flipt/pkg/provider"
     "github.com/open-feature/go-sdk/openfeature"
 )
 
@@ -37,12 +37,12 @@ func main() {
     openfeature.SetProvider(flipt.NewProvider())
 
     client := openfeature.NewClient("my-app")
-    value, err := client.BooleanValue(context.Background(), "v2_enabled", false, openfeature.EvaluationContext{
-        TargetingKey: "tim@apple.com",
-        Attributes: map[string]interface{}{
+    value, err := client.BooleanValue(context.Background(), "v2_enabled", false, openfeature.NewEvaluationContext(
+        "tim@apple.com",
+        map[string]interface{}{
             "favorite_color": "blue",
         },
-    })
+    ))
 
     if err != nil {
         panic(err)


### PR DESCRIPTION
## This PR

Corrects the Flipt provider import statement in the README to one that works.
I also updated the example to use the new SDK syntax for evaluation context creation.

### Related Issues

No issues, we just had a question on our Discourse that brought this to our attention:
https://community.flipt.io/t/trouble-getting-started-with-open-feature-go-provider/18/3

