### PR TITLE
feat: Default port to 8015 if in-process resolver is used. #523

### DIFF
--- a/providers/flagd/pkg/configuration.go
+++ b/providers/flagd/pkg/configuration.go
@@ -12,16 +12,14 @@ type ResolverType string
 
 // Naming and defaults must comply with flagd environment variables
 const (
-	defaultMaxCacheSize  int = 1000
-	defaultRpcPort           = 8013
-	defaultInProcessPort     = 8015
-	// Deprecated: defaultPort is deprecated, please use either `defaultRpcPort` or `defaultInProcessPort`
-	defaultPort                       = defaultRpcPort
-	defaultMaxEventStreamRetries      = 5
-	defaultTLS                   bool = false
-	defaultCache                      = cache.LRUValue
-	defaultHost                       = "localhost"
-	defaultResolver                   = rpc
+	defaultMaxCacheSize          int    = 1000
+	defaultRpcPort               uint16 = 8013
+	defaultInProcessPort         uint16 = 8015
+	defaultMaxEventStreamRetries        = 5
+	defaultTLS                   bool   = false
+	defaultCache                        = cache.LRUValue
+	defaultHost                         = "localhost"
+	defaultResolver                     = rpc
 
 	rpc       ResolverType = "rpc"
 	inProcess ResolverType = "in-process"
@@ -79,8 +77,8 @@ func (cfg *providerConfiguration) updateFromEnvVar() {
 		if err != nil {
 			cfg.log.Error(err,
 				fmt.Sprintf(
-					"invalid env config for %s provided, using default value: %d",
-					flagdPortEnvironmentVariableName, defaultPort,
+					"invalid env config for %s provided, using default value: %d or %d depending on resolver",
+					flagdPortEnvironmentVariableName, defaultRpcPort, defaultInProcessPort,
 				))
 		} else {
 			cfg.Port = uint16(port)

--- a/providers/flagd/pkg/configuration.go
+++ b/providers/flagd/pkg/configuration.go
@@ -12,8 +12,11 @@ type ResolverType string
 
 // Naming and defaults must comply with flagd environment variables
 const (
-	defaultMaxCacheSize          int  = 1000
-	defaultPort                       = 8013
+	defaultMaxCacheSize  int = 1000
+	defaultRpcPort           = 8013
+	defaultInProcessPort     = 8015
+	// Deprecated: defaultPort is deprecated, please use either `defaultRpcPort` or `defaultInProcessPort`
+	defaultPort                       = defaultRpcPort
 	defaultMaxEventStreamRetries      = 5
 	defaultTLS                   bool = false
 	defaultCache                      = cache.LRUValue
@@ -60,7 +63,6 @@ func newDefaultConfiguration(log logr.Logger) *providerConfiguration {
 		Host:                             defaultHost,
 		log:                              log,
 		MaxCacheSize:                     defaultMaxCacheSize,
-		Port:                             defaultPort,
 		Resolver:                         defaultResolver,
 		TLSEnabled:                       defaultTLS,
 	}

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -42,6 +42,14 @@ func NewProvider(opts ...ProviderOption) *Provider {
 		opt(provider)
 	}
 
+	if provider.providerConfiguration.Port == 0 {
+		if provider.providerConfiguration.Resolver == inProcess {
+			provider.providerConfiguration.Port = defaultInProcessPort
+		} else {
+			provider.providerConfiguration.Port = defaultRpcPort
+		}
+	}
+
 	cacheService := cache.NewCacheService(
 		provider.providerConfiguration.CacheType,
 		provider.providerConfiguration.MaxCacheSize,

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -11,6 +11,7 @@ import (
 func TestNewProvider(t *testing.T) {
 	tests := []struct {
 		name                string
+		expectedResolver    ResolverType
 		expectPort          uint16
 		expectHost          string
 		expectCacheType     cache.Type
@@ -24,7 +25,8 @@ func TestNewProvider(t *testing.T) {
 	}{
 		{
 			name:                "default construction",
-			expectPort:          defaultPort,
+			expectedResolver:    rpc,
+			expectPort:          defaultRpcPort,
 			expectHost:          defaultHost,
 			expectCacheType:     defaultCache,
 			expectCertPath:      "",
@@ -36,6 +38,7 @@ func TestNewProvider(t *testing.T) {
 		},
 		{
 			name:                "with options",
+			expectedResolver:    inProcess,
 			expectPort:          9090,
 			expectHost:          "myHost",
 			expectCacheType:     cache.LRUValue,
@@ -46,6 +49,7 @@ func TestNewProvider(t *testing.T) {
 			expectSocketPath:    "/socket",
 			expectTlsEnabled:    true,
 			options: []ProviderOption{
+				WithInProcessResolver(),
 				WithSocketPath("/socket"),
 				WithOtelInterceptor(true),
 				WithLRUCache(2500),
@@ -53,6 +57,38 @@ func TestNewProvider(t *testing.T) {
 				WithCertificatePath("/path"),
 				WithHost("myHost"),
 				WithPort(9090),
+			},
+		},
+		{
+			name:                "default port handling with in-process resolver",
+			expectedResolver:    inProcess,
+			expectPort:          defaultInProcessPort,
+			expectHost:          defaultHost,
+			expectCacheType:     defaultCache,
+			expectCertPath:      "",
+			expectMaxRetries:    defaultMaxEventStreamRetries,
+			expectCacheSize:     defaultMaxCacheSize,
+			expectOtelIntercept: false,
+			expectSocketPath:    "",
+			expectTlsEnabled:    false,
+			options: []ProviderOption{
+				WithInProcessResolver(),
+			},
+		},
+		{
+			name:                "default port handling with in-process resolver",
+			expectedResolver:    rpc,
+			expectPort:          defaultRpcPort,
+			expectHost:          defaultHost,
+			expectCacheType:     defaultCache,
+			expectCertPath:      "",
+			expectMaxRetries:    defaultMaxEventStreamRetries,
+			expectCacheSize:     defaultMaxCacheSize,
+			expectOtelIntercept: false,
+			expectSocketPath:    "",
+			expectTlsEnabled:    false,
+			options: []ProviderOption{
+				WithRPCResolver(),
 			},
 		},
 	}


### PR DESCRIPTION
closes: #523

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

The flagd provider defaults to RPC mode and the corresponding port (8013) using the [evaluation proto](https://buf.build/open-feature/flagd/docs/main:flagd.evaluation.v1). If the in-process resolver is selected, it operates in in-process mode using the [sync proto](https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1), but still uses port 8013, instead of defaulting to the correct port (8015, for the sync proto).

We improve the configuration by defaulting to port 8015 if the in-process resolver is selected.