### PR TITLE
docs: change code in launchdarkly readme from JSON to javascript

### DIFF
--- a/providers/launchdarkly/README.md
+++ b/providers/launchdarkly/README.md
@@ -26,7 +26,7 @@ context needs to be well-formed.
 
 ### Single context
 
-```JSON
+```javascript
 {
   // The "kind" of the context. Required.
   // Cannot be missing, empty, "multi", or "kind".
@@ -62,7 +62,7 @@ context needs to be well-formed.
 
 ### Multi context
 
-```JSON
+```javascript
 {
   // The "kind" of the context. Required.
   // Must be "multi".


### PR DESCRIPTION
For some reason, the fenced code blocks were showing up as background-highlighted-dark-red when the fenced code blocks had type "json", and were difficult to read.

And my goodness they were ugly!

## This PR
- fixes appearance of code blocks in launchdarkly provider readme

### Related Issues
n/a

### Notes
n/a

### Follow-up Tasks
n/a

### How to test
n/a
