### PR TITLE
fix: Make OFREP option public

### DIFF
--- a/providers/ofrep/provider.go
+++ b/providers/ofrep/provider.go
@@ -15,11 +15,11 @@ type Provider struct {
 	evaluator Evaluator
 }
 
-type option func(*outbound.Configuration)
+type Option func(*outbound.Configuration)
 
 // NewProvider returns an OFREP provider configured with provided configuration.
 // The only mandatory configuration is the baseUri, which is the base path of the OFREP service implementation.
-func NewProvider(baseUri string, options ...option) *Provider {
+func NewProvider(baseUri string, options ...Option) *Provider {
 	cfg := outbound.Configuration{
 		BaseURI: baseUri,
 	}


### PR DESCRIPTION
## This PR
It is not possible to add a conditional option because it has to be set using the `NewProvider` method.

Ater this PR we should be able to do something like this:
```go
	var options = make([]ofrep.Option, 0)
	options = append(options, ofrep.WithClient(&http.Client{}))
	ofrep.NewProvider("http://localhost:8016", options...)
```
