### PR TITLE
fix: Don't panic if metadata not present in the response

### DIFF
--- a/providers/ofrep/internal/evaluate/resolver.go
+++ b/providers/ofrep/internal/evaluate/resolver.go
@@ -147,18 +147,21 @@ type successDto struct {
 }
 
 func toSuccessDto(e evaluationSuccess) (*successDto, *of.ResolutionError) {
-	m, ok := e.Metadata.(map[string]interface{})
-	if !ok {
-		resErr := of.NewParseErrorResolutionError("metadata must be a map of string keys and arbitrary values")
-		return nil, &resErr
+	dto := &successDto{
+		Value:   e.Value,
+		Reason:  e.Reason,
+		Variant: e.Variant,
 	}
 
-	return &successDto{
-		Value:    e.Value,
-		Reason:   e.Reason,
-		Variant:  e.Variant,
-		Metadata: m,
-	}, nil
+	if e.Metadata != nil {
+		m, ok := e.Metadata.(map[string]interface{})
+		if !ok {
+			resErr := of.NewParseErrorResolutionError("metadata must be a map of string keys and arbitrary values")
+			return nil, &resErr
+		}
+		dto.Metadata = m
+	}
+	return dto, nil
 }
 
 type request struct {

--- a/providers/ofrep/internal/evaluate/resolver_test.go
+++ b/providers/ofrep/internal/evaluate/resolver_test.go
@@ -35,6 +35,13 @@ var successWithInvalidMetadata = evaluationSuccess{
 	Metadata: "metadata",
 }
 
+var successWithoutMetadata = evaluationSuccess{
+	Value:   true,
+	Key:     "flagA",
+	Reason:  string(of.StaticReason),
+	Variant: "true",
+}
+
 func TestSuccess200(t *testing.T) {
 	t.Run("success evaluation response", func(t *testing.T) {
 		successBytes, err := json.Marshal(success)
@@ -103,6 +110,24 @@ func TestSuccess200(t *testing.T) {
 		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
 
 		validateErrorCode(success, resolutionError, of.ParseErrorCode, t)
+	})
+	t.Run("no metadata in the ofrep response", func(t *testing.T) {
+		b, err := json.Marshal(successWithoutMetadata)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resolver := OutboundResolver{client: mockOutbound{
+			rsp: outbound.Resolution{
+				Status: http.StatusOK,
+				Data:   b,
+			},
+		}}
+		success, _ := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+
+		if len(success.Metadata) > 0 {
+			t.Errorf("should not have metadata, but got %v", success.Metadata)
+		}
 	})
 }
 


### PR DESCRIPTION
## This PR
`metadata` is not a mandatory field, if the ofrep response does not have a `metadata` field the provider panic.
This PR make it optional to have a `metadata` field.
