### PR TITLE
fix: Should return a parse error if error while parsing

### DIFF
--- a/providers/ofrep/internal/evaluate/resolver.go
+++ b/providers/ofrep/internal/evaluate/resolver.go
@@ -49,7 +49,7 @@ func (g *OutboundResolver) resolveSingle(ctx context.Context, key string, evalCt
 		var success evaluationSuccess
 		err := json.Unmarshal(rsp.Data, &success)
 		if err != nil {
-			resErr := of.NewGeneralResolutionError(fmt.Sprintf("error parsing the response: %v", err))
+			resErr := of.NewParseErrorResolutionError(fmt.Sprintf("error parsing the response: %v", err))
 			return nil, &resErr
 		}
 		return toSuccessDto(success)

--- a/providers/ofrep/internal/evaluate/resolver_test.go
+++ b/providers/ofrep/internal/evaluate/resolver_test.go
@@ -85,7 +85,7 @@ func TestSuccess200(t *testing.T) {
 		}}
 		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
 
-		validateErrorCode(success, resolutionError, of.GeneralCode, t)
+		validateErrorCode(success, resolutionError, of.ParseErrorCode, t)
 	})
 
 	t.Run("invalid metadata results in a parsing error", func(t *testing.T) {


### PR DESCRIPTION
## This PR
Should return a parse error if error while parsing
