### PR TITLE
fix: Default GO parsing is float64 for int

### DIFF
--- a/providers/ofrep/internal/evaluate/flags.go
+++ b/providers/ofrep/internal/evaluate/flags.go
@@ -150,6 +150,18 @@ func (h Flags) ResolveInt(ctx context.Context, key string, defaultValue int64, e
 		value = int64(evalSuccess.Value.(int))
 	case int64:
 		value = evalSuccess.Value.(int64)
+	case float64:
+		value = int64(evalSuccess.Value.(float64))
+		if float64(value) != evalSuccess.Value.(float64) {
+			return of.IntResolutionDetail{
+				Value: defaultValue,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					ResolutionError: of.NewTypeMismatchResolutionError(fmt.Sprintf(
+						"resolved value %v is not of integer type", evalSuccess.Value)),
+					Reason: of.ErrorReason,
+				},
+			}
+		}
 	default:
 		return of.IntResolutionDetail{
 			Value: defaultValue,

--- a/providers/ofrep/internal/evaluate/flags_test.go
+++ b/providers/ofrep/internal/evaluate/flags_test.go
@@ -50,6 +50,13 @@ var successInt64 = successDto{
 	Metadata: nil,
 }
 
+var successInt64WithFloat64 = successDto{
+	Value:    float64(10),
+	Reason:   string(of.StaticReason),
+	Variant:  "10",
+	Metadata: nil,
+}
+
 var successFloat = successDto{
 	Value:    float32(1.10),
 	Reason:   string(of.StaticReason),
@@ -142,6 +149,14 @@ func TestIntegerEvaluation(t *testing.T) {
 			},
 			defaultValue: 1,
 			expect:       successInt64.Value.(int64),
+		},
+		{
+			name: "Success evaluation - int64 with a float64",
+			resolver: mockResolver{
+				success: &successInt64WithFloat64,
+			},
+			defaultValue: 1,
+			expect:       int64(successInt64WithFloat64.Value.(float64)),
 		},
 		{
 			name: "Error evaluation",


### PR DESCRIPTION
## This PR
By default GO when unmarshaling a JSON string GO is mapping all `int` as `float64`.
Before this PR we had only type_mismatch error for int.