### PR TITLE
feat(fo-feature-flag): add DisableCacheMetrics to disable metrics collector

### DIFF
--- a/providers/go-feature-flag/pkg/provider_options.go
+++ b/providers/go-feature-flag/pkg/provider_options.go
@@ -1,8 +1,9 @@
 package gofeatureflag
 
 import (
-	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"time"
+
+	ffclient "github.com/thomaspoignant/go-feature-flag"
 )
 
 // ProviderOptions is the struct containing the provider options you can
@@ -28,6 +29,9 @@ type ProviderOptions struct {
 
 	// DisableCache (optional) set to true if you would like that every flag evaluation goes to the GO Feature Flag directly.
 	DisableCache bool
+
+	// DisableDataCollector (optional) set to true if you would like to disable the cache metrics collection.
+	DisableDataCollector bool
 
 	// FlagCacheSize (optional) is the maximum number of flag events we keep in memory to cache your flags.
 	// default: 10000


### PR DESCRIPTION
…metrics

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->



- Adds `DisableCacheMetrics` to disable cache hit metric collection. Backchannel creates back traffic, which is not always needed or even creates additional workload. 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

