### PR TITLE
ci: add z4kn4fein from ConfigCat as component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -7,6 +7,7 @@ components:
     - toddbaert
   providers/configcat:
     - rcrowe
+    - z4kn4fein
   providers/flagd:
     - bacherfl
     - Kavindu-Dodan


### PR DESCRIPTION
## This PR
- Adds @z4kn4fein (ConfigCat) to the component owner's list of the ConfigCat provider. The intention behind this is that we (ConfigCat) would like to mark the provider in this repo as the official ConfigCat OpenFeature Go provider, and we would like to participate in its development and maintenance.
