### PR TITLE
fix(ofrep): close http response body after using it

### DIFF
--- a/providers/ofrep/internal/evaluate/flags_test.go
+++ b/providers/ofrep/internal/evaluate/flags_test.go
@@ -126,7 +126,7 @@ func TestBooleanEvaluation(t *testing.T) {
 			expect:       false,
 		},
 		{
-			name: "disbaled flag",
+			name: "disabled flag",
 			resolver: mockResolver{
 				success: &successDisabled,
 			},
@@ -192,7 +192,7 @@ func TestIntegerEvaluation(t *testing.T) {
 			expect:       1,
 		},
 		{
-			name: "disbaled flag",
+			name: "disabled flag",
 			resolver: mockResolver{
 				success: &successDisabled,
 			},
@@ -250,7 +250,7 @@ func TestFloatEvaluation(t *testing.T) {
 			expect:       1.05,
 		},
 		{
-			name: "disbaled flag",
+			name: "disabled flag",
 			resolver: mockResolver{
 				success: &successDisabled,
 			},
@@ -341,7 +341,7 @@ func TestObjectEvaluation(t *testing.T) {
 			expect:       map[string]interface{}{},
 		},
 		{
-			name: "disbaled flag",
+			name: "disabled flag",
 			resolver: mockResolver{
 				success: &successDisabled,
 			},

--- a/providers/ofrep/internal/outbound/http.go
+++ b/providers/ofrep/internal/outbound/http.go
@@ -70,6 +70,7 @@ func (h *Outbound) Single(ctx context.Context, key string, payload []byte) (*Res
 	if err != nil {
 		return nil, err
 	}
+	defer rsp.Body.Close()
 
 	b, err := io.ReadAll(rsp.Body)
 	if err != nil {


### PR DESCRIPTION


<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- This PR fixes the memory leak when using http client.
- It also cleanups few tests and typos.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

