### PR TITLE
docs(main): correct function name and fix formatting in OpenTelemetry Hook documentation

### DIFF
--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -114,7 +114,7 @@ These attributes are added at the `After` stage of the hook.
 
 ```go
 
-NewTracesHook(WithMetricsAttributeSetter(
+NewTracesHook(WithTracesAttributeSetter(
     func(metadata openfeature.FlagMetadata) []attribute.KeyValue {
 		// custom attribute extraction logic
 

--- a/hooks/open-telemetry/README.md
+++ b/hooks/open-telemetry/README.md
@@ -103,11 +103,11 @@ span.End()
 
 ### Options
 
-### WithErrorStatusEnabled
+#### WithErrorStatusEnabled
 
 Enable setting span status to `Error` in case of an error. Default behavior is disabled, span status is unset for errors.
 
-### WithTracesAttributeSetter
+#### WithTracesAttributeSetter
 
 This constructor options allows to provide a custom callback to extract dimensions from `FlagMetadata`.
 These attributes are added at the `After` stage of the hook.


### PR DESCRIPTION
## This PR

- Fixes the incorrect function name in the `WithTracesAttributeSetter` example.
- Corrects formatting inconsistencies under the **Options** heading in the Traces hook section.

### Related Issues

N/A

### Notes

- Ensures that the documentation examples are accurate and consistent.
- Improves the readability of the documentation by fixing heading levels.

### Follow-up Tasks

N/A

### How to test

- Read through the updated documentation to verify that the function names and formatting are correct.