### PR TITLE
feat: Support supplying a custom sync provider for in-process flagd

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -57,9 +57,27 @@ openfeature.SetProvider(provider)
 The provider will attempt to detect file changes, but this is a best-effort attempt as file system events differ between operating systems.
 This mode is useful for local development, tests and offline applications.
 
+#### Custom sync provider
+
+In-process resolver can also be configured with a custom sync provider to change how the in-process resolver fetches flags.
+The custom sync provider must implement the [sync.ISync interface](https://github.com/open-feature/flagd/blob/main/core/pkg/sync/isync.go)
+
+```go
+var syncProvider sync.ISync = MyAwesomeSyncProvider{}
+var syncProviderUri string = "myawesome://sync.uri"
+
+provider := flagd.NewProvider(
+        flagd.WithInProcessResolver(),
+        flagd.WithCustomSyncProvider(syncProvider, syncProviderUri))
+openfeature.SetProvider(provider)
+```
+
 > [!IMPORTANT]
-> Note that you can only use a single flag source (either gRPC or offline file) for the in-process resolver. 
-> If both sources are configured, offline mode will be selected.
+> Note that the in-process resolver can only use a single flag source.
+> If multiple sources are configured then only one would be selected based on the following order of preference:
+>   1. Custom sync provider
+>   2. Offline file
+>   3. gRPC
 
 ## Configuration options
 

--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -60,7 +60,16 @@ This mode is useful for local development, tests and offline applications.
 #### Custom sync provider
 
 In-process resolver can also be configured with a custom sync provider to change how the in-process resolver fetches flags.
-The custom sync provider must implement the [sync.ISync interface](https://github.com/open-feature/flagd/blob/main/core/pkg/sync/isync.go)
+The custom sync provider must implement the [sync.ISync interface](https://github.com/open-feature/flagd/blob/main/core/pkg/sync/isync.go). Optional URI can be provided for the custom sync provider.
+
+```go
+var syncProvider sync.ISync = MyAwesomeSyncProvider{}
+
+provider := flagd.NewProvider(
+        flagd.WithInProcessResolver(),
+        flagd.WithCustomSyncProvider(syncProvider))
+openfeature.SetProvider(provider)
+```
 
 ```go
 var syncProvider sync.ISync = MyAwesomeSyncProvider{}
@@ -68,7 +77,7 @@ var syncProviderUri string = "myawesome://sync.uri"
 
 provider := flagd.NewProvider(
         flagd.WithInProcessResolver(),
-        flagd.WithCustomSyncProvider(syncProvider, syncProviderUri))
+        flagd.WithCustomSyncProviderAndUri(syncProvider, syncProviderUri))
 openfeature.SetProvider(provider)
 ```
 

--- a/providers/flagd/pkg/configuration.go
+++ b/providers/flagd/pkg/configuration.go
@@ -2,10 +2,12 @@ package flagd
 
 import (
 	"fmt"
-	"github.com/go-logr/logr"
-	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/cache"
 	"os"
 	"strconv"
+
+	"github.com/go-logr/logr"
+	"github.com/open-feature/flagd/core/pkg/sync"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/cache"
 )
 
 type ResolverType string
@@ -52,6 +54,8 @@ type providerConfiguration struct {
 	Selector                         string
 	SocketPath                       string
 	TLSEnabled                       bool
+	CustomSyncProvider               sync.ISync
+	CustomSyncProviderUri            string
 
 	log logr.Logger
 }

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -3,13 +3,16 @@ package flagd
 import (
 	"context"
 	"fmt"
+
+	parallel "sync"
+
 	"github.com/go-logr/logr"
+	"github.com/open-feature/flagd/core/pkg/sync"
 	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/cache"
 	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/logger"
-	"github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/in_process"
+	process "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/in_process"
 	rpcService "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/rpc"
 	of "github.com/open-feature/go-sdk/openfeature"
-	"sync"
 )
 
 type Provider struct {
@@ -18,7 +21,7 @@ type Provider struct {
 	providerConfiguration *providerConfiguration
 	service               IService
 	status                of.State
-	mtx                   sync.RWMutex
+	mtx                   parallel.RWMutex
 
 	eventStream chan of.Event
 }
@@ -71,12 +74,14 @@ func NewProvider(opts ...ProviderOption) *Provider {
 			provider.providerConfiguration.EventStreamConnectionMaxAttempts)
 	} else {
 		service = process.NewInProcessService(process.Configuration{
-			Host:              provider.providerConfiguration.Host,
-			Port:              provider.providerConfiguration.Port,
-			Selector:          provider.providerConfiguration.Selector,
-			TargetUri:         provider.providerConfiguration.TargetUri,
-			TLSEnabled:        provider.providerConfiguration.TLSEnabled,
-			OfflineFlagSource: provider.providerConfiguration.OfflineFlagSourcePath,
+			Host:                  provider.providerConfiguration.Host,
+			Port:                  provider.providerConfiguration.Port,
+			Selector:              provider.providerConfiguration.Selector,
+			TargetUri:             provider.providerConfiguration.TargetUri,
+			TLSEnabled:            provider.providerConfiguration.TLSEnabled,
+			OfflineFlagSource:     provider.providerConfiguration.OfflineFlagSourcePath,
+			CustomSyncProvider:    provider.providerConfiguration.CustomSyncProvider,
+			CustomSyncProviderUri: provider.providerConfiguration.CustomSyncProviderUri,
 		})
 	}
 
@@ -322,5 +327,14 @@ func WithSelector(selector string) ProviderOption {
 func FromEnv() ProviderOption {
 	return func(p *Provider) {
 		p.providerConfiguration.updateFromEnvVar()
+	}
+}
+
+// WithCustomSyncProvider provides a custom implementation of the sync.ISync interface used by the inProcess Service
+// This is only useful with inProcess resolver type
+func WithCustomSyncProvider(customSyncProvider sync.ISync, customSyncProviderUri string) ProviderOption {
+	return func(p *Provider) {
+		p.providerConfiguration.CustomSyncProvider = customSyncProvider
+		p.providerConfiguration.CustomSyncProviderUri = customSyncProviderUri
 	}
 }

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -15,6 +15,10 @@ import (
 	of "github.com/open-feature/go-sdk/openfeature"
 )
 
+const (
+	defaultCustomSyncProviderUri = "syncprovider://custom"
+)
+
 type Provider struct {
 	initialized           bool
 	logger                logr.Logger
@@ -332,7 +336,13 @@ func FromEnv() ProviderOption {
 
 // WithCustomSyncProvider provides a custom implementation of the sync.ISync interface used by the inProcess Service
 // This is only useful with inProcess resolver type
-func WithCustomSyncProvider(customSyncProvider sync.ISync, customSyncProviderUri string) ProviderOption {
+func WithCustomSyncProvider(customSyncProvider sync.ISync) ProviderOption {
+	return WithCustomSyncProviderAndUri(customSyncProvider, defaultCustomSyncProviderUri)
+}
+
+// WithCustomSyncProvider provides a custom implementation of the sync.ISync interface used by the inProcess Service
+// This is only useful with inProcess resolver type
+func WithCustomSyncProviderAndUri(customSyncProvider sync.ISync, customSyncProviderUri string) ProviderOption {
 	return func(p *Provider) {
 		p.providerConfiguration.CustomSyncProvider = customSyncProvider
 		p.providerConfiguration.CustomSyncProviderUri = customSyncProviderUri

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -132,7 +132,7 @@ func TestNewProvider(t *testing.T) {
 			},
 		},
 		{
-			name:                        "with custom sync provider with in-process resolver",
+			name:                        "with custom sync provider and uri with in-process resolver",
 			expectedResolver:            inProcess,
 			expectPort:                  defaultInProcessPort,
 			expectHost:                  defaultHost,
@@ -148,7 +148,27 @@ func TestNewProvider(t *testing.T) {
 			expectCustomSyncProviderUri: "testsyncer://custom.uri",
 			options: []ProviderOption{
 				WithInProcessResolver(),
-				WithCustomSyncProvider(customSyncProvider, "testsyncer://custom.uri"),
+				WithCustomSyncProviderAndUri(customSyncProvider, "testsyncer://custom.uri"),
+			},
+		},
+		{
+			name:                        "with custom sync provider with in-process resolver",
+			expectedResolver:            inProcess,
+			expectPort:                  defaultInProcessPort,
+			expectHost:                  defaultHost,
+			expectCacheType:             defaultCache,
+			expectTargetUri:             "",
+			expectCertPath:              "",
+			expectMaxRetries:            defaultMaxEventStreamRetries,
+			expectCacheSize:             defaultMaxCacheSize,
+			expectOtelIntercept:         false,
+			expectSocketPath:            "",
+			expectTlsEnabled:            false,
+			expectCustomSyncProvider:    customSyncProvider,
+			expectCustomSyncProviderUri: defaultCustomSyncProviderUri,
+			options: []ProviderOption{
+				WithInProcessResolver(),
+				WithCustomSyncProvider(customSyncProvider),
 			},
 		},
 	}

--- a/providers/flagd/pkg/service/in_process/do_nothing_custom_sync_provider.go
+++ b/providers/flagd/pkg/service/in_process/do_nothing_custom_sync_provider.go
@@ -30,6 +30,8 @@ func (fps DoNothingCustomSyncProvider) ReSync(ctx context.Context, dataSync chan
 // Returns an implementation of sync.ISync interface that does nothing at all.
 // The returned implementation does not conform to the sync.DataSync contract.
 // This is useful only for unit tests.
-func NewDoNothingCustomSyncProvider() sync.ISync {
+func NewDoNothingCustomSyncProvider() DoNothingCustomSyncProvider {
 	return DoNothingCustomSyncProvider{}
 }
+
+var _ sync.ISync = &DoNothingCustomSyncProvider{}

--- a/providers/flagd/pkg/service/in_process/do_nothing_custom_sync_provider.go
+++ b/providers/flagd/pkg/service/in_process/do_nothing_custom_sync_provider.go
@@ -1,0 +1,35 @@
+package process
+
+import (
+	context "context"
+
+	"github.com/open-feature/flagd/core/pkg/sync"
+)
+
+// Fake implementation of sync.ISync. Does not conform to the contract because it does not send any events to the DataSync.
+// Only used for unit tests.
+type DoNothingCustomSyncProvider struct {
+}
+
+func (fps DoNothingCustomSyncProvider) Init(ctx context.Context) error {
+	return nil
+}
+
+func (fps DoNothingCustomSyncProvider) IsReady() bool {
+	return true
+}
+
+func (fps DoNothingCustomSyncProvider) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
+	return nil
+}
+
+func (fps DoNothingCustomSyncProvider) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error {
+	return nil
+}
+
+// Returns an implementation of sync.ISync interface that does nothing at all.
+// The returned implementation does not conform to the sync.DataSync contract.
+// This is useful only for unit tests.
+func NewDoNothingCustomSyncProvider() sync.ISync {
+	return DoNothingCustomSyncProvider{}
+}

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -3,6 +3,10 @@ package process
 import (
 	"context"
 	"fmt"
+
+	"regexp"
+	parallel "sync"
+
 	"github.com/open-feature/flagd/core/pkg/evaluator"
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/model"
@@ -13,9 +17,7 @@ import (
 	"github.com/open-feature/flagd/core/pkg/sync/grpc/credentials"
 	of "github.com/open-feature/go-sdk/openfeature"
 	"golang.org/x/exp/maps"
-	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	parallel "sync"
 )
 
 // InProcess service implements flagd flag evaluation in-process.
@@ -31,12 +33,14 @@ type InProcess struct {
 }
 
 type Configuration struct {
-	Host              any
-	Port              any
-	TargetUri         string
-	Selector          string
-	TLSEnabled        bool
-	OfflineFlagSource string
+	Host                  any
+	Port                  any
+	TargetUri             string
+	Selector              string
+	TLSEnabled            bool
+	OfflineFlagSource     string
+	CustomSyncProvider    sync.ISync
+	CustomSyncProviderUri string
 }
 
 func NewInProcessService(cfg Configuration) *InProcess {
@@ -269,6 +273,10 @@ func (i *InProcess) appendMetadata(evalMetadata map[string]interface{}) {
 
 // makeSyncProvider is a helper to create sync.ISync and return the underlying uri used by it to the caller
 func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string) {
+	if cfg.CustomSyncProvider != nil {
+		return cfg.CustomSyncProvider, cfg.CustomSyncProviderUri
+	}
+
 	if cfg.OfflineFlagSource != "" {
 		// file sync provider
 		log.Info("operating in in-process mode with offline flags sourced from " + cfg.OfflineFlagSource)

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -274,6 +274,7 @@ func (i *InProcess) appendMetadata(evalMetadata map[string]interface{}) {
 // makeSyncProvider is a helper to create sync.ISync and return the underlying uri used by it to the caller
 func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string) {
 	if cfg.CustomSyncProvider != nil {
+		log.Info("operating in in-process mode with a custom sync provider at " + cfg.CustomSyncProviderUri)
 		return cfg.CustomSyncProvider, cfg.CustomSyncProviderUri
 	}
 

--- a/providers/flagd/pkg/service/in_process/service_custom_sync_provider_test.go
+++ b/providers/flagd/pkg/service/in_process/service_custom_sync_provider_test.go
@@ -1,0 +1,15 @@
+package process
+
+import (
+	"testing"
+)
+
+func TestInProcessWithCustomSyncProvider(t *testing.T) {
+	customSyncProvider := NewDoNothingCustomSyncProvider()
+	service := NewInProcessService(Configuration{CustomSyncProvider: customSyncProvider, CustomSyncProviderUri: "not tested here"})
+
+	// If custom sync provider is supplied the in-process service should use it.
+	if service.sync != customSyncProvider {
+		t.Fatalf("Expected service.sync to be the mockCustomSyncProvider, but got %s", service.sync)
+	}
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- When the user is using in-process flagd, allows them to supply a `sync.ISync` implementation of their own that can fetch the flag config in any way they like.

### Notes
<!-- any additional notes for this PR -->
This PR provides the capability in Go that was recently added in [Java](https://github.com/open-feature/java-sdk-contrib/pull/900).
