### PR TITLE
fix: IntEvaluation when cannot be parsed

### DIFF
--- a/providers/unleash/pkg/provider.go
+++ b/providers/unleash/pkg/provider.go
@@ -120,16 +120,28 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValu
 		Value: defaultValue,
 		ProviderResolutionDetail: of.ProviderResolutionDetail{
 			Reason:          of.ErrorReason,
-			ResolutionError: of.NewFlagNotFoundResolutionError(fmt.Sprintf("FloatEvaluation type error for %s", flag)),
+			ResolutionError: of.NewTypeMismatchResolutionError(fmt.Sprintf("FloatEvaluation type error for %s", flag)),
 		},
 	}
 }
 
 func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, evalCtx of.FlattenedContext) of.IntResolutionDetail {
 	res := p.ObjectEvaluation(ctx, flag, defaultValue, evalCtx)
+	if strValue, ok := res.Value.(string); ok {
+		value, err := strconv.ParseInt(strValue, 10, 64)
+		if err == nil {
+			return of.IntResolutionDetail{
+				Value:                    value,
+				ProviderResolutionDetail: res.ProviderResolutionDetail,
+			}
+		}
+	}
 	return of.IntResolutionDetail{
-		Value:                    res.Value.(int64),
-		ProviderResolutionDetail: res.ProviderResolutionDetail,
+		Value: defaultValue,
+		ProviderResolutionDetail: of.ProviderResolutionDetail{
+			Reason:          of.ErrorReason,
+			ResolutionError: of.NewTypeMismatchResolutionError(fmt.Sprintf("IntEvaluation type error for %s", flag)),
+		},
 	}
 }
 

--- a/providers/unleash/pkg/provider_test.go
+++ b/providers/unleash/pkg/provider_test.go
@@ -39,23 +39,28 @@ func TestBooleanEvaluation(t *testing.T) {
 }
 
 func TestIntEvaluation(t *testing.T) {
-	resolution := provider.BooleanEvaluation(context.Background(), "int-flag", false, nil)
+	defaultValue := int64(0)
+	expectedValue := int64(123)
+	resolution := provider.IntEvaluation(context.Background(), "int-flag", defaultValue, nil)
 	enabled, _ := resolution.ProviderResolutionDetail.FlagMetadata.GetBool("enabled")
 	if !enabled {
 		t.Fatalf("Expected feature to be enabled")
 	}
-	if !resolution.Value {
+	if resolution.ProviderResolutionDetail.Variant != "aaaa" {
+		t.Fatalf("Expected variant name")
+	}
+	if resolution.Value != expectedValue {
 		t.Fatalf("Expected one of the variant payloads")
 	}
 
 	t.Run("evalCtx empty", func(t *testing.T) {
-		resolution := provider.BooleanEvaluation(context.Background(), "non-existing-flag", false, nil)
-		require.Equal(t, false, resolution.Value)
+		resolution := provider.IntEvaluation(context.Background(), "non-existing-flag", defaultValue, nil)
+		require.Equal(t, defaultValue, resolution.Value)
 	})
 
 	t.Run("evalCtx empty fallback to default", func(t *testing.T) {
-		resolution := provider.BooleanEvaluation(context.Background(), "non-existing-flag", true, nil)
-		require.Equal(t, true, resolution.Value)
+		resolution := provider.IntEvaluation(context.Background(), "non-existing-flag", defaultValue, nil)
+		require.Equal(t, defaultValue, resolution.Value)
 	})
 }
 
@@ -167,6 +172,7 @@ func TestEvaluationMethods(t *testing.T) {
 		{flag: "DateExample", defaultValue: false, evalCtx: of.FlattenedContext{}, expected: true, expectedError: ""},
 		{flag: "variant-flag", defaultValue: false, evalCtx: of.FlattenedContext{}, expected: true, expectedError: ""},
 		{flag: "double-flag", defaultValue: 9.9, evalCtx: of.FlattenedContext{}, expected: 1.23, expectedError: ""},
+		{flag: "int-flag", defaultValue: int64(1), evalCtx: of.FlattenedContext{}, expected: int64(123), expectedError: ""},
 		{flag: "variant-flag", defaultValue: "fallback", evalCtx: of.FlattenedContext{}, expected: "v1", expectedError: ""},
 		{flag: "json-flag", defaultValue: "fallback", evalCtx: of.FlattenedContext{}, expected: "{\n  \"k1\": \"v1\"\n}", expectedError: ""},
 		{flag: "csv-flag", defaultValue: "fallback", evalCtx: of.FlattenedContext{}, expected: "a,b,c", expectedError: ""},


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes `IntEvaluation` for Unleash provider.
- fixes `TestIntEvaluation` to run correctly and adds `int-flag` to `TestEvaluationMethods`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Related to https://github.com/open-feature/go-sdk-contrib/pull/465