### PR TITLE
fix: IntEvalution, FloatEvalution when disabled or missing flags

### DIFF
--- a/providers/unleash/pkg/demo_app_toggles.json
+++ b/providers/unleash/pkg/demo_app_toggles.json
@@ -123,7 +123,7 @@
           ],
           "variants": [
               {
-                  "name": "aaaa",
+                  "name": "int-flag-variant",
                   "weight": 1000,
                   "payload": {
                       "type": "number",
@@ -148,7 +148,7 @@
           ],
           "variants": [
               {
-                  "name": "aaaa",
+                  "name": "double-flag-variant",
                   "weight": 1000,
                   "payload": {
                       "type": "number",
@@ -157,6 +157,21 @@
                   "overrides": [],
                   "weightType": "variable",
                   "stickiness": "default"
+              }
+          ]
+      },
+      {
+          "name": "disabled-flag",
+          "type": "release",
+          "enabled": false,
+          "variants": [
+              {
+                  "name": "disabled-flag-variant",
+                  "weight": 1000,
+                  "payload": {
+                      "type": "string",
+                      "value": "disabled flag variant value"
+                  }
               }
           ]
       },

--- a/providers/unleash/pkg/provider.go
+++ b/providers/unleash/pkg/provider.go
@@ -107,6 +107,14 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVa
 
 func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, evalCtx of.FlattenedContext) of.FloatResolutionDetail {
 	res := p.ObjectEvaluation(ctx, flag, defaultValue, evalCtx)
+
+	if value, ok := res.Value.(float64); ok {
+		return of.FloatResolutionDetail{
+			Value:                    value,
+			ProviderResolutionDetail: res.ProviderResolutionDetail,
+		}
+	}
+
 	if strValue, ok := res.Value.(string); ok {
 		value, err := strconv.ParseFloat(strValue, 64)
 		if err == nil {
@@ -127,6 +135,14 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValu
 
 func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, evalCtx of.FlattenedContext) of.IntResolutionDetail {
 	res := p.ObjectEvaluation(ctx, flag, defaultValue, evalCtx)
+
+	if value, ok := res.Value.(int64); ok {
+		return of.IntResolutionDetail{
+			Value:                    value,
+			ProviderResolutionDetail: res.ProviderResolutionDetail,
+		}
+	}
+
 	if strValue, ok := res.Value.(string); ok {
 		value, err := strconv.ParseInt(strValue, 10, 64)
 		if err == nil {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes the `TYPE_MISMATCH` error in `IntEvaluation` and `FloatEvaluation` when flags are disabled or missing.
- fixes test cases for `IntEvaluation` and `FloatEvaluation`.
- fixes an issue where test cases are not reading the bootstrap file due to a backup file.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Related to https://github.com/open-feature/go-sdk-contrib/pull/607