### PR TITLE
feat: Support Exporter Metadata

### DIFF
--- a/providers/go-feature-flag/pkg/controller/goff_api.go
+++ b/providers/go-feature-flag/pkg/controller/goff_api.go
@@ -22,6 +22,8 @@ type GoFeatureFlagApiOptions struct {
 	// (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
 	// Default: null
 	APIKey string
+	// Metadata (optional) If we set metadata, it will be sent with every data collection requests along with the events.
+	Metadata map[string]interface{}
 }
 
 type GoFeatureFlagAPI struct {
@@ -39,9 +41,10 @@ func NewGoFeatureFlagAPI(options GoFeatureFlagApiOptions) GoFeatureFlagAPI {
 func (g *GoFeatureFlagAPI) CollectData(events []model.FeatureEvent) error {
 	u, _ := url.Parse(g.options.Endpoint)
 	u.Path = path.Join(u.Path, "v1", "data", "collector")
+
 	reqBody := model.DataCollectorRequest{
 		Events: events,
-		Meta:   map[string]string{"provider": "go", "openfeature": "true"},
+		Meta:   g.options.Metadata,
 	}
 
 	jsonData, err := json.Marshal(reqBody)

--- a/providers/go-feature-flag/pkg/controller/goff_api.go
+++ b/providers/go-feature-flag/pkg/controller/goff_api.go
@@ -22,8 +22,8 @@ type GoFeatureFlagApiOptions struct {
 	// (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
 	// Default: null
 	APIKey string
-	// Metadata (optional) If we set metadata, it will be sent with every data collection requests along with the events.
-	Metadata map[string]interface{}
+	// ExporterMetadata (optional) If we set metadata, it will be sent with every data collection requests along with the events.
+	ExporterMetadata map[string]interface{}
 }
 
 type GoFeatureFlagAPI struct {
@@ -44,7 +44,7 @@ func (g *GoFeatureFlagAPI) CollectData(events []model.FeatureEvent) error {
 
 	reqBody := model.DataCollectorRequest{
 		Events: events,
-		Meta:   g.options.Metadata,
+		Meta:   g.options.ExporterMetadata,
 	}
 
 	jsonData, err := json.Marshal(reqBody)

--- a/providers/go-feature-flag/pkg/controller/goff_api_test.go
+++ b/providers/go-feature-flag/pkg/controller/goff_api_test.go
@@ -28,9 +28,9 @@ func Test_CollectDataAPI(t *testing.T) {
 			name:    "Valid api call",
 			wantErr: assert.NoError,
 			options: controller.GoFeatureFlagApiOptions{
-				Endpoint: "http://localhost:1031",
-				APIKey:   "",
-				Metadata: map[string]interface{}{"openfeature": true, "provider": "go"},
+				Endpoint:         "http://localhost:1031",
+				APIKey:           "",
+				ExporterMetadata: map[string]interface{}{"openfeature": true, "provider": "go"},
 			},
 			events: []model.FeatureEvent{
 				{
@@ -75,9 +75,9 @@ func Test_CollectDataAPI(t *testing.T) {
 			name:    "Valid api call with API Key",
 			wantErr: assert.NoError,
 			options: controller.GoFeatureFlagApiOptions{
-				Endpoint: "http://localhost:1031",
-				APIKey:   "my-key",
-				Metadata: map[string]interface{}{"openfeature": true, "provider": "go"},
+				Endpoint:         "http://localhost:1031",
+				APIKey:           "my-key",
+				ExporterMetadata: map[string]interface{}{"openfeature": true, "provider": "go"},
 			},
 			events: []model.FeatureEvent{
 				{

--- a/providers/go-feature-flag/pkg/controller/goff_api_test.go
+++ b/providers/go-feature-flag/pkg/controller/goff_api_test.go
@@ -30,6 +30,7 @@ func Test_CollectDataAPI(t *testing.T) {
 			options: controller.GoFeatureFlagApiOptions{
 				Endpoint: "http://localhost:1031",
 				APIKey:   "",
+				Metadata: map[string]interface{}{"openfeature": true, "provider": "go"},
 			},
 			events: []model.FeatureEvent{
 				{
@@ -68,7 +69,7 @@ func Test_CollectDataAPI(t *testing.T) {
 				headers.Set(controller.ContentTypeHeader, controller.ApplicationJson)
 				return headers
 			}(),
-			wantReqBody: "{\"events\":[{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"ABCD\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"},{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"EFGH\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"}],\"meta\":{\"openfeature\":\"true\",\"provider\":\"go\"}}",
+			wantReqBody: "{\"events\":[{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"ABCD\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"},{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"EFGH\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"}],\"meta\":{\"openfeature\":true,\"provider\":\"go\"}}",
 		},
 		{
 			name:    "Valid api call with API Key",
@@ -76,6 +77,7 @@ func Test_CollectDataAPI(t *testing.T) {
 			options: controller.GoFeatureFlagApiOptions{
 				Endpoint: "http://localhost:1031",
 				APIKey:   "my-key",
+				Metadata: map[string]interface{}{"openfeature": true, "provider": "go"},
 			},
 			events: []model.FeatureEvent{
 				{
@@ -115,7 +117,7 @@ func Test_CollectDataAPI(t *testing.T) {
 				headers.Set(controller.AuthorizationHeader, controller.BearerPrefix+"my-key")
 				return headers
 			}(),
-			wantReqBody: "{\"events\":[{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"ABCD\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"},{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"EFGH\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"}],\"meta\":{\"openfeature\":\"true\",\"provider\":\"go\"}}",
+			wantReqBody: "{\"events\":[{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"ABCD\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"},{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"EFGH\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"}],\"meta\":{\"openfeature\":true,\"provider\":\"go\"}}",
 		},
 		{
 			name:    "Request failed",

--- a/providers/go-feature-flag/pkg/model/data_collector_request.go
+++ b/providers/go-feature-flag/pkg/model/data_collector_request.go
@@ -1,6 +1,6 @@
 package model
 
 type DataCollectorRequest struct {
-	Events []FeatureEvent    `json:"events"`
-	Meta   map[string]string `json:"meta"`
+	Events []FeatureEvent         `json:"events"`
+	Meta   map[string]interface{} `json:"meta"`
 }

--- a/providers/go-feature-flag/pkg/provider.go
+++ b/providers/go-feature-flag/pkg/provider.go
@@ -55,17 +55,17 @@ func NewProviderWithContext(ctx context.Context, options ProviderOptions) (*Prov
 	cacheCtrl := controller.NewCache(options.FlagCacheSize, options.FlagCacheTTL, options.DisableCache)
 
 	// Adding metadata to the GO Feature Flag provider to be sent to the exporter
-	if options.GOFeatureFlagMetadata == nil {
-		options.GOFeatureFlagMetadata = make(map[string]interface{})
+	if options.ExporterMetadata == nil {
+		options.ExporterMetadata = make(map[string]interface{})
 	}
-	options.GOFeatureFlagMetadata["provider"] = "go"
-	options.GOFeatureFlagMetadata["openfeature"] = true
+	options.ExporterMetadata["provider"] = "go"
+	options.ExporterMetadata["openfeature"] = true
 
 	goffAPI := controller.NewGoFeatureFlagAPI(controller.GoFeatureFlagApiOptions{
-		Endpoint:   options.Endpoint,
-		HTTPClient: options.HTTPClient,
-		APIKey:     options.APIKey,
-		Metadata:   options.GOFeatureFlagMetadata,
+		Endpoint:         options.Endpoint,
+		HTTPClient:       options.HTTPClient,
+		APIKey:           options.APIKey,
+		ExporterMetadata: options.ExporterMetadata,
 	})
 	dataCollectorManager := controller.NewDataCollectorManager(
 		goffAPI,

--- a/providers/go-feature-flag/pkg/provider.go
+++ b/providers/go-feature-flag/pkg/provider.go
@@ -53,10 +53,19 @@ func NewProviderWithContext(ctx context.Context, options ProviderOptions) (*Prov
 	}))
 	ofrepProvider := ofrep.NewProvider(options.Endpoint, ofrepOptions...)
 	cacheCtrl := controller.NewCache(options.FlagCacheSize, options.FlagCacheTTL, options.DisableCache)
+
+	// Adding metadata to the GO Feature Flag provider to be sent to the exporter
+	if options.GOFeatureFlagMetadata == nil {
+		options.GOFeatureFlagMetadata = make(map[string]interface{})
+	}
+	options.GOFeatureFlagMetadata["provider"] = "go"
+	options.GOFeatureFlagMetadata["openfeature"] = true
+
 	goffAPI := controller.NewGoFeatureFlagAPI(controller.GoFeatureFlagApiOptions{
 		Endpoint:   options.Endpoint,
 		HTTPClient: options.HTTPClient,
 		APIKey:     options.APIKey,
+		Metadata:   options.GOFeatureFlagMetadata,
 	})
 	dataCollectorManager := controller.NewDataCollectorManager(
 		goffAPI,

--- a/providers/go-feature-flag/pkg/provider_options.go
+++ b/providers/go-feature-flag/pkg/provider_options.go
@@ -62,6 +62,10 @@ type ProviderOptions struct {
 	// Use -1 if you want to deactivate polling.
 	// default: 120000ms
 	FlagChangePollingInterval time.Duration
+
+	// GOFeatureFlagMetadata (optional) is the metadata we send to the GO Feature Flag relay proxy when we report the
+	// evaluation data usage.
+	GOFeatureFlagMetadata map[string]interface{}
 }
 
 func (o *ProviderOptions) Validation() error {

--- a/providers/go-feature-flag/pkg/provider_options.go
+++ b/providers/go-feature-flag/pkg/provider_options.go
@@ -63,9 +63,12 @@ type ProviderOptions struct {
 	// default: 120000ms
 	FlagChangePollingInterval time.Duration
 
-	// GOFeatureFlagMetadata (optional) is the metadata we send to the GO Feature Flag relay proxy when we report the
+	// ExporterMetadata (optional) is the metadata we send to the GO Feature Flag relay proxy when we report the
 	// evaluation data usage.
-	GOFeatureFlagMetadata map[string]interface{}
+	//
+	// ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information of this
+	// field will not be added to your feature events.
+	ExporterMetadata map[string]interface{}
 }
 
 func (o *ProviderOptions) Validation() error {

--- a/providers/go-feature-flag/pkg/provider_test.go
+++ b/providers/go-feature-flag/pkg/provider_test.go
@@ -1013,6 +1013,7 @@ func TestProvider_DataCollectorHook(t *testing.T) {
 		// convert cli.collectorRequests[0] to  DataCollectorRequest
 		var dataCollectorRequest model.DataCollectorRequest
 		err = json.Unmarshal([]byte(cli.collectorRequests[0]), &dataCollectorRequest)
+		assert.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{
 			"openfeature": true,
 			"provider":    "go",

--- a/providers/go-feature-flag/pkg/provider_test.go
+++ b/providers/go-feature-flag/pkg/provider_test.go
@@ -982,12 +982,12 @@ func TestProvider_DataCollectorHook(t *testing.T) {
 	t.Run("DataCollectorHook is called for success and call API", func(t *testing.T) {
 		cli := mockClient{}
 		options := gofeatureflag.ProviderOptions{
-			Endpoint:              "https://gofeatureflag.org/",
-			HTTPClient:            NewMockClient(cli.roundTripFunc),
-			DisableCache:          false,
-			DataFlushInterval:     100 * time.Millisecond,
-			DisableDataCollector:  false,
-			GOFeatureFlagMetadata: map[string]interface{}{"toto": 123, "tata": "titi"},
+			Endpoint:             "https://gofeatureflag.org/",
+			HTTPClient:           NewMockClient(cli.roundTripFunc),
+			DisableCache:         false,
+			DataFlushInterval:    100 * time.Millisecond,
+			DisableDataCollector: false,
+			ExporterMetadata:     map[string]interface{}{"toto": 123, "tata": "titi"},
 		}
 		provider, err := gofeatureflag.NewProvider(options)
 		defer provider.Shutdown()


### PR DESCRIPTION
## This PR
GO Feature Flag exporter is now supporting adding extra parameters as metadata.
Those parameters are static informations provided during the initialisation to be added in the meta field when calling the exporter.

In the GO Feature Flag we will have those information available in the exporter.

See https://github.com/thomaspoignant/go-feature-flag/issues/2936 for more information.

### Related Issues
Fixes https://github.com/thomaspoignant/go-feature-flag/issues/2937
