### PR TITLE
ci: Bump version of GO in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ e2e:
 	go clean -testcache && go list -f '{{.Dir}}/...' -m | xargs -I{} go test -tags=e2e {}
 
 lint: 
-	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
+	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run --deadline=3m --timeout=3m $(module)/...;)
 
 new-provider:


### PR DESCRIPTION
## This PR
Considering that `1.21` has reached end of life, I'll propose to bump GO to version `1.23`.
https://endoflife.date/go

