### PR TITLE
fix(flagd): Fixed possible nil pointer exception with svcMetadata in service.go

### DIFF
--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -189,6 +189,34 @@ func TestNewProvider(t *testing.T) {
 				WithProviderID("testProvider"),
 			},
 		},
+		{
+			name:             "with selector only with in-process resolver",
+			expectedResolver: inProcess,
+			expectHost:       defaultHost,
+			expectPort:       defaultInProcessPort,
+			expectCacheType:  defaultCache,
+			expectCacheSize:  defaultMaxCacheSize,
+			expectMaxRetries: defaultMaxEventStreamRetries,
+			expectSelector:   "flags=test",
+			options: []ProviderOption{
+				WithInProcessResolver(),
+				WithSelector("flags=test"),
+			},
+		},
+		{
+			name:             "with providerID only with in-process resolver",
+			expectedResolver: inProcess,
+			expectHost:       defaultHost,
+			expectPort:       defaultInProcessPort,
+			expectCacheType:  defaultCache,
+			expectCacheSize:  defaultMaxCacheSize,
+			expectMaxRetries: defaultMaxEventStreamRetries,
+			expectProviderID: "testProvider",
+			options: []ProviderOption{
+				WithInProcessResolver(),
+				WithProviderID("testProvider"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -50,9 +50,8 @@ func NewInProcessService(cfg Configuration) *InProcess {
 	iSync, uri := makeSyncProvider(cfg, log)
 
 	// service specific metadata
-	var svcMetadata model.Metadata
+	svcMetadata := make(model.Metadata, 2)
 	if cfg.Selector != "" {
-		svcMetadata = make(model.Metadata, 1)
 		svcMetadata["scope"] = cfg.Selector
 	}
 	if cfg.ProviderID != "" {


### PR DESCRIPTION
## This PR
- fixes potential nil pointer exception when using WithProviderID without WithSelectorID
- adds tests to catch that in the future