### PR TITLE
feat(flagd): Added WithGrpcDialOptionsOverride provider option

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -144,6 +144,27 @@ openfeature.SetProvider(flagd.NewProvider(
     ))
 ```
 
+### gRPC DialOptions override
+
+The `GrpcDialOptionsOverride` is meant for connection of the in-process resolver to a Sync API implementation on a host/port,
+that might require special credentials or headers.
+
+```go
+creds := customSync.CreateCredentials(...)
+
+dialOptions := []grpc.DialOption{
+        grpc.WithTransportCredentials(creds.TransportCredentials()),
+        grpc.WithPerRPCCredentials(creds.PerRPCCredentials()),
+        grpc.WithAuthority(...),
+    }
+
+openfeature.SetProvider(flagd.NewProvider(
+        flagd.WithInProcessResolver(),
+        flagd.WithHost("example.com/flagdSyncApi"), flagd.WithPort(443),
+        flagd.WithGrpcDialOptionsOverride(dialOptions),
+    ))
+```
+
 ## Supported Events
 
 The flagd provider emits `PROVIDER_READY`, `PROVIDER_ERROR` and `PROVIDER_CONFIGURATION_CHANGED` events.

--- a/providers/flagd/pkg/configuration.go
+++ b/providers/flagd/pkg/configuration.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/open-feature/flagd/core/pkg/sync"
 	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/cache"
+	"google.golang.org/grpc"
 )
 
 type ResolverType string
@@ -58,6 +59,7 @@ type providerConfiguration struct {
 	TLSEnabled                       bool
 	CustomSyncProvider               sync.ISync
 	CustomSyncProviderUri            string
+	GrpcDialOptionsOverride          []grpc.DialOption
 
 	log logr.Logger
 }

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -13,6 +13,7 @@ import (
 	process "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/in_process"
 	rpcService "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/rpc"
 	of "github.com/open-feature/go-sdk/openfeature"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -78,15 +79,16 @@ func NewProvider(opts ...ProviderOption) *Provider {
 			provider.providerConfiguration.EventStreamConnectionMaxAttempts)
 	} else {
 		service = process.NewInProcessService(process.Configuration{
-			Host:                  provider.providerConfiguration.Host,
-			Port:                  provider.providerConfiguration.Port,
-			ProviderID:            provider.providerConfiguration.ProviderID,
-			Selector:              provider.providerConfiguration.Selector,
-			TargetUri:             provider.providerConfiguration.TargetUri,
-			TLSEnabled:            provider.providerConfiguration.TLSEnabled,
-			OfflineFlagSource:     provider.providerConfiguration.OfflineFlagSourcePath,
-			CustomSyncProvider:    provider.providerConfiguration.CustomSyncProvider,
-			CustomSyncProviderUri: provider.providerConfiguration.CustomSyncProviderUri,
+			Host:                    provider.providerConfiguration.Host,
+			Port:                    provider.providerConfiguration.Port,
+			ProviderID:              provider.providerConfiguration.ProviderID,
+			Selector:                provider.providerConfiguration.Selector,
+			TargetUri:               provider.providerConfiguration.TargetUri,
+			TLSEnabled:              provider.providerConfiguration.TLSEnabled,
+			OfflineFlagSource:       provider.providerConfiguration.OfflineFlagSourcePath,
+			CustomSyncProvider:      provider.providerConfiguration.CustomSyncProvider,
+			CustomSyncProviderUri:   provider.providerConfiguration.CustomSyncProviderUri,
+			GrpcDialOptionsOverride: provider.providerConfiguration.GrpcDialOptionsOverride,
 		})
 	}
 
@@ -354,5 +356,15 @@ func WithCustomSyncProviderAndUri(customSyncProvider sync.ISync, customSyncProvi
 	return func(p *Provider) {
 		p.providerConfiguration.CustomSyncProvider = customSyncProvider
 		p.providerConfiguration.CustomSyncProviderUri = customSyncProviderUri
+	}
+}
+
+// WithGrpcDialOptionsOverride provides a set of custom grps.DialOption that will fully override the gRPC dial options used by
+// the InProcess resolver with gRPC syncer. All the other provider options that also set dial options (e.g. WithTLS, or WithCertificatePath)
+// will be silently ignored.
+// This is only useful with inProcess resolver type
+func WithGrpcDialOptionsOverride(grpcDialOptionsOverride []grpc.DialOption) ProviderOption {
+	return func(p *Provider) {
+		p.providerConfiguration.GrpcDialOptionsOverride = grpcDialOptionsOverride
 	}
 }

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	parallel "sync"
 
+	googlegrpc "google.golang.org/grpc"
+
 	"github.com/open-feature/flagd/core/pkg/evaluator"
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/model"
@@ -33,15 +35,16 @@ type InProcess struct {
 }
 
 type Configuration struct {
-	Host                  any
-	Port                  any
-	TargetUri             string
-	ProviderID            string
-	Selector              string
-	TLSEnabled            bool
-	OfflineFlagSource     string
-	CustomSyncProvider    sync.ISync
-	CustomSyncProviderUri string
+	Host                    any
+	Port                    any
+	TargetUri               string
+	ProviderID              string
+	Selector                string
+	TLSEnabled              bool
+	OfflineFlagSource       string
+	CustomSyncProvider      sync.ISync
+	CustomSyncProviderUri   string
+	GrpcDialOptionsOverride []googlegrpc.DialOption
 }
 
 func NewInProcessService(cfg Configuration) *InProcess {
@@ -301,12 +304,13 @@ func makeSyncProvider(cfg Configuration, log *logger.Logger) (sync.ISync, string
 	log.Info("operating in in-process mode with flags sourced from " + uri)
 
 	return &grpc.Sync{
-		CredentialBuilder: &credentials.CredentialBuilder{},
-		Logger:            log,
-		Secure:            cfg.TLSEnabled,
-		ProviderID:        cfg.ProviderID,
-		Selector:          cfg.Selector,
-		URI:               uri,
+		CredentialBuilder:       &credentials.CredentialBuilder{},
+		GrpcDialOptionsOverride: cfg.GrpcDialOptionsOverride,
+		Logger:                  log,
+		Secure:                  cfg.TLSEnabled,
+		ProviderID:              cfg.ProviderID,
+		Selector:                cfg.Selector,
+		URI:                     uri,
 	}, uri
 }
 


### PR DESCRIPTION
## This PR
- Exposes the [recently added `GrpcDialOptionsOverride`](https://github.com/open-feature/flagd/pull/1563) in `grpc.Sync` in flagd core (v.0.11.2) as `flagd.WithGrpcDialOptionsOverride(...)` provider option