### PR TITLE
chore(goff): Support new hook format

### DIFF
--- a/providers/go-feature-flag/pkg/hook/data_collector_hook.go
+++ b/providers/go-feature-flag/pkg/hook/data_collector_hook.go
@@ -13,10 +13,11 @@ func NewDataCollectorHook(dataCollectorManager *controller.DataCollectorManager)
 }
 
 type dataCollectorHook struct {
+	openfeature.UnimplementedHook
 	dataCollectorManager *controller.DataCollectorManager
 }
 
-func (d *dataCollectorHook) After(ctx context.Context, hookCtx openfeature.HookContext,
+func (d *dataCollectorHook) After(_ context.Context, hookCtx openfeature.HookContext,
 	evalDetails openfeature.InterfaceEvaluationDetails, hint openfeature.HookHints) error {
 	if evalDetails.Reason != openfeature.CachedReason {
 		// we send it only when cached because the evaluation will be collected directly in the relay-proxy
@@ -37,7 +38,7 @@ func (d *dataCollectorHook) After(ctx context.Context, hookCtx openfeature.HookC
 	return nil
 }
 
-func (d *dataCollectorHook) Error(ctx context.Context, hookCtx openfeature.HookContext,
+func (d *dataCollectorHook) Error(_ context.Context, hookCtx openfeature.HookContext,
 	err error, hint openfeature.HookHints) {
 	event := model.FeatureEvent{
 		Kind:         "feature",
@@ -51,13 +52,4 @@ func (d *dataCollectorHook) Error(ctx context.Context, hookCtx openfeature.HookC
 		Source:       "PROVIDER_CACHE",
 	}
 	_ = d.dataCollectorManager.AddEvent(event)
-}
-
-func (d *dataCollectorHook) Before(context.Context, openfeature.HookContext, openfeature.HookHints) (*openfeature.EvaluationContext, error) {
-	// Do nothing, needed to satisfy the interface
-	return nil, nil
-}
-
-func (d *dataCollectorHook) Finally(context.Context, openfeature.HookContext, openfeature.HookHints) {
-	// Do nothing, needed to satisfy the interface
 }

--- a/providers/go-feature-flag/pkg/hook/evaluation_enrichment_hook.go
+++ b/providers/go-feature-flag/pkg/hook/evaluation_enrichment_hook.go
@@ -10,18 +10,8 @@ func NewEvaluationEnrichmentHook(exporterMetadata map[string]interface{}) openfe
 }
 
 type evaluationEnrichmentHook struct {
+	openfeature.UnimplementedHook
 	exporterMetadata map[string]interface{}
-}
-
-func (d *evaluationEnrichmentHook) After(_ context.Context, _ openfeature.HookContext,
-	_ openfeature.InterfaceEvaluationDetails, _ openfeature.HookHints) error {
-	// Do nothing, needed to satisfy the interface
-	return nil
-}
-
-func (d *evaluationEnrichmentHook) Error(_ context.Context, _ openfeature.HookContext,
-	_ error, _ openfeature.HookHints) {
-	// Do nothing, needed to satisfy the interface
 }
 
 func (d *evaluationEnrichmentHook) Before(_ context.Context, hookCtx openfeature.HookContext, _ openfeature.HookHints) (*openfeature.EvaluationContext, error) {
@@ -38,8 +28,4 @@ func (d *evaluationEnrichmentHook) Before(_ context.Context, hookCtx openfeature
 	}
 	newCtx := openfeature.NewEvaluationContext(hookCtx.EvaluationContext().TargetingKey(), attributes)
 	return &newCtx, nil
-}
-
-func (d *evaluationEnrichmentHook) Finally(context.Context, openfeature.HookContext, openfeature.HookHints) {
-	// Do nothing, needed to satisfy the interface
 }


### PR DESCRIPTION
## This PR
In this PR we are now using `openfeature.UnimplementedHook` has a base for the hooks in order to follow the new `finally` pattern.

### Related Issues
#328