### PR TITLE
feat!: updated OTel finally hook for upcoming changes

### DIFF
--- a/hooks/open-telemetry/go.mod
+++ b/hooks/open-telemetry/go.mod
@@ -3,7 +3,7 @@ module github.com/open-feature/go-sdk-contrib/hooks/open-telemetry
 go 1.21
 
 require (
-	github.com/open-feature/go-sdk v1.11.0
+	github.com/open-feature/go-sdk v1.14.1
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/metric v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
@@ -15,6 +15,6 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 // indirect
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 )

--- a/hooks/open-telemetry/go.sum
+++ b/hooks/open-telemetry/go.sum
@@ -13,6 +13,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/open-feature/go-sdk v1.11.0 h1:4cp9rXl16ZvlMCef7O+I3vQSXae8DzAF0SfV9mvYInw=
 github.com/open-feature/go-sdk v1.11.0/go.mod h1:+rkJhLBtYsJ5PZNddAgFILhRAAxwrJ32aU7UEUm4zQI=
+github.com/open-feature/go-sdk v1.14.1 h1:jcxjCIG5Up3XkgYwWN5Y/WWfc6XobOhqrIwjyDBsoQo=
+github.com/open-feature/go-sdk v1.14.1/go.mod h1:t337k0VB/t/YxJ9S0prT30ISUHwYmUd/jhUZgFcOvGg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
@@ -29,6 +31,7 @@ go.opentelemetry.io/otel/trace v1.28.0 h1:GhQ9cUuQGmNDd5BTCP2dAvv75RdMxEfTmYejp+
 go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVfM3/yv2OlIHaI=
 golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 h1:/RIbNt/Zr7rVhIkQhooTxCxFcdWLGIKnZA4IXNFSrvo=
 golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=

--- a/hooks/open-telemetry/pkg/metrics.go
+++ b/hooks/open-telemetry/pkg/metrics.go
@@ -122,7 +122,7 @@ func (h *MetricsHook) Error(ctx context.Context, hCtx openfeature.HookContext, e
 			attribute.String(semconv.ExceptionEventName, err.Error())))
 }
 
-func (h *MetricsHook) Finally(ctx context.Context, hCtx openfeature.HookContext, hint openfeature.HookHints) {
+func (h *MetricsHook) Finally(ctx context.Context, hCtx openfeature.HookContext, evalCtx openfeature.InterfaceEvaluationDetails, hint openfeature.HookHints) {
 	h.activeCounter.Add(ctx, -1, api.WithAttributes(semconv.FeatureFlagKey(hCtx.FlagKey())))
 }
 

--- a/hooks/open-telemetry/pkg/metrics_test.go
+++ b/hooks/open-telemetry/pkg/metrics_test.go
@@ -170,6 +170,15 @@ func TestMetricsHook_FinallyStage(t *testing.T) {
 
 	ctx := context.Background()
 
+	evalDetails := openfeature.InterfaceEvaluationDetails{
+		Value: true,
+		EvaluationDetails: openfeature.EvaluationDetails{
+			FlagKey:          "flagA",
+			FlagType:         openfeature.Boolean,
+			ResolutionDetail: openfeature.ResolutionDetail{},
+		},
+	}
+
 	hookContext := hookContext()
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
@@ -180,7 +189,7 @@ func TestMetricsHook_FinallyStage(t *testing.T) {
 	}
 
 	// when
-	metricsHook.Finally(ctx, hookContext, hookHints)
+	metricsHook.Finally(ctx, hookContext, evalDetails, hookHints)
 
 	// then
 	var data metricdata.ResourceMetrics
@@ -214,6 +223,15 @@ func TestMetricsHook_ActiveCounterShouldBeZero(t *testing.T) {
 
 	ctx := context.Background()
 
+	evalDetails := openfeature.InterfaceEvaluationDetails{
+		Value: true,
+		EvaluationDetails: openfeature.EvaluationDetails{
+			FlagKey:          "flagA",
+			FlagType:         openfeature.Boolean,
+			ResolutionDetail: openfeature.ResolutionDetail{},
+		},
+	}
+
 	hookContext := hookContext()
 	hookHints := openfeature.NewHookHints(map[string]interface{}{})
 
@@ -230,7 +248,7 @@ func TestMetricsHook_ActiveCounterShouldBeZero(t *testing.T) {
 		return
 	}
 
-	metricsHook.Finally(ctx, hookContext, hookHints)
+	metricsHook.Finally(ctx, hookContext, evalDetails, hookHints)
 
 	// then
 	var data metricdata.ResourceMetrics


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- bumped the `go-sdk` version to 1.14.1
- added `evalDetails` to the parameters passed in the `Finally` hook in `metrics` hook
- updated the `metrics_test` to have the new `evalDetails`

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #642 

### Notes
<!-- any additional notes for this PR -->

- not sure if there is a specific way to bump the `go-sdk` version to the unreleased version with the change to the `Hook` it currently throws an error where it is called in `metrics` because the type issue
```
var _ openfeature.Hook = &MetricsHook{}
```

- in the issue it states to explicitly mention the breaking but ok because of spec in the release notes, I am not sure if that is something I can do in this PR and I just can't find how in the contributing or if it is after the reviewing

