### PR TITLE
feat(flagd): add Shutdown support for in-process sync

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -43,7 +43,8 @@ In the above example, in-process handlers attempt to connect to a sync service o
 #### Custom sync provider
 
 In-process resolver can also be configured with a custom sync provider to change how the in-process resolver fetches flags.
-The custom sync provider must implement the [sync.ISync interface](https://github.com/open-feature/flagd/blob/main/core/pkg/sync/isync.go). Optional URI can be provided for the custom sync provider.
+The custom sync provider must implement the [sync.ISync interface](https://github.com/open-feature/flagd/blob/main/core/pkg/sync/isync.go). Optional URI can be provided for the custom sync provider.  
+The custom sync provider can implement the _sync.Shutdowner_ interface from [service](https://github.com/open-feature/go-sdk-contrib/blob/main/providers/flagd/pkg/service/in_process/service.go).
 
 ```go
 var syncProvider sync.ISync = MyAwesomeSyncProvider{}

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	parallel "sync"
 
+	"go.uber.org/zap"
 	googlegrpc "google.golang.org/grpc"
 
 	"github.com/open-feature/flagd/core/pkg/evaluator"
@@ -123,7 +124,7 @@ func (i *InProcess) Init() error {
 				if shutdowner, ok := i.sync.(Shutdowner); ok {
 					err := shutdowner.Shutdown()
 					if err != nil {
-						i.logger.Error("Error shutdown sync provider: " + err.Error())
+						i.logger.Error("Error shutdown sync provider", zap.Error(err))
 					}
 				}
 				return


### PR DESCRIPTION
Add Shutdown support for in-process sync.

This is needed for a follow-up PR that implements custom sync provider which intended to be shutdown.