### PR TITLE
feat(aws-ssm): implement provider

### DIFF
--- a/providers/aws-ssm/LICENCE
+++ b/providers/aws-ssm/LICENCE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/providers/aws-ssm/README.md
+++ b/providers/aws-ssm/README.md
@@ -1,0 +1,68 @@
+# AWS SSM OpenFeature Provider for Go
+
+OpenFeature Go provider implementation that integrates with AWS Systems Manager Parameter Store (SSM) for feature flag management.
+
+## Installation
+
+```shell
+go get github.com/open-feature/go-sdk/openfeature
+go get github.com/open-feature/go-sdk-contrib/providers/aws-ssm
+```
+
+## Usage
+
+Here's a basic example of using the AWS SSM provider:
+
+```go
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/open-feature/go-sdk/openfeature"
+	ssm "github.com/open-feature/go-sdk-contrib/providers/aws-ssm"
+)
+
+func main() {
+
+	// Retrieve AWS Config
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+
+	if err != nil {
+		log.Fatalf("failed to load AWS config: %v", err)
+	}
+
+	// Initialize the provider
+	provider := ssm.NewProvider(cfg)
+	err := openfeature.SetProvider(provider)
+
+	// Create OpenFeature client
+	client := openfeature.NewClient("")
+
+	// Evaluate a feature flag
+	val, err := client.BooleanValue(context.TODO(), "/path/to/feature/flag", false, nil)
+	fmt.Printf("val: %+v - error: %v\n", val, err)
+}
+```
+
+## Configuration
+
+The provider uses AWS SSM Parameter Store to store and retrieve feature flag values. Feature flag paths in OpenFeature correspond to SSM parameter paths. For example:
+
+- OpenFeature flag path: `/features/new-feature`
+- SSM parameter path: `/features/new-feature`
+
+The provider supports both secure string parameters (encrypted with AWS KMS) and standard string parameters in SSM Parameter Store.
+
+## AWS Credentials
+
+The provider uses the default AWS credential chain, which means it will look for credentials in this order:
+1. Environment variables
+2. Shared credentials file (~/.aws/credentials)
+3. AWS config file (~/.aws/config)
+4. IAM role credentials (when running on AWS)
+
+## Security
+
+The provider supports secure parameters in SSM Parameter Store, which are encrypted at rest using AWS KMS. When using secure parameters, make sure your AWS credentials have the necessary permissions to decrypt the parameters.

--- a/providers/aws-ssm/aws.go
+++ b/providers/aws-ssm/aws.go
@@ -1,0 +1,400 @@
+package awsssm
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+// SSMMetadataKey is the key used in flag metadata to store SSM result metadata
+const SSMMetadataKey = "SSMMetadata"
+
+type awsService struct {
+	client     ssmClient
+	decryption bool
+}
+
+type ssmClient interface {
+	GetParameter(ctx context.Context, params *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+}
+
+func newAWSService(cfg aws.Config) (*awsService) {
+
+	client := ssm.NewFromConfig(cfg)
+
+	return &awsService{
+		client: client,
+	}
+}
+
+func (svc *awsService) ResolveBoolean(ctx context.Context, flag string, defaultValue bool, evalCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+
+	res, err := svc.getValueFromSSM(ctx, flag)
+
+	if err != nil {
+		return openfeature.BoolResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	b, err := strconv.ParseBool(*res.Parameter.Value)
+
+	if err != nil {
+		return openfeature.BoolResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	return openfeature.BoolResolutionDetail{
+		Value: b,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			Reason: openfeature.StaticReason,
+			FlagMetadata: openfeature.FlagMetadata{
+				SSMMetadataKey: res.ResultMetadata,
+			},
+		},
+	}
+
+}
+
+func (svc *awsService) ResolveString(ctx context.Context, flag string, defaultValue string, evalCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+
+	res, err := svc.getValueFromSSM(ctx, flag)
+
+	if err != nil {
+		return openfeature.StringResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	return openfeature.StringResolutionDetail{
+		Value: *res.Parameter.Value,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			Reason: openfeature.StaticReason,
+			FlagMetadata: openfeature.FlagMetadata{
+				SSMMetadataKey: res.ResultMetadata,
+			},
+		},
+	}
+
+}
+
+func (svc *awsService) ResolveInt(ctx context.Context, flag string, defaultValue int64, evalCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+	res, err := svc.getValueFromSSM(ctx, flag)
+
+	if err != nil {
+		return openfeature.IntResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	i, err := strconv.ParseInt(*res.Parameter.Value, 10, 64)
+
+	if err != nil {
+		return openfeature.IntResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	return openfeature.IntResolutionDetail{
+		Value: i,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			Reason: openfeature.StaticReason,
+			FlagMetadata: openfeature.FlagMetadata{
+				"SSMMetadata": res.ResultMetadata,
+			},
+		},
+	}
+}
+
+func (svc *awsService) ResolveFloat(ctx context.Context, flag string, defaultValue float64, evalCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+	res, err := svc.getValueFromSSM(ctx, flag)
+
+	if err != nil {
+		return openfeature.FloatResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	f, err := strconv.ParseFloat(*res.Parameter.Value, 64)
+
+	if err != nil {
+		return openfeature.FloatResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	return openfeature.FloatResolutionDetail{
+		Value: f,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			Reason: openfeature.StaticReason,
+			FlagMetadata: openfeature.FlagMetadata{
+				SSMMetadataKey: res.ResultMetadata,
+			},
+		},
+	}
+}
+
+func (svc *awsService) ResolveObject(ctx context.Context, flag string, defaultValue any, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	res, err := svc.getValueFromSSM(ctx, flag)
+
+	if err != nil {
+		return openfeature.InterfaceResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
+			},
+		}
+	}
+
+	return openfeature.InterfaceResolutionDetail{
+		Value: defaultValue,
+		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+			Reason: openfeature.StaticReason,
+			FlagMetadata: openfeature.FlagMetadata{
+				SSMMetadataKey: res.ResultMetadata,
+			},
+		},
+	}
+}
+
+func (svc *awsService) getValueFromSSM(ctx context.Context, flag string) (*ssm.GetParameterOutput, error) {
+
+	param := &ssm.GetParameterInput{
+		Name:           &flag,
+		WithDecryption: &svc.decryption,
+	}
+
+	res, err := svc.client.GetParameter(ctx, param)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+59 changes: 59 additions & 0 deletions 59
+providers/aws-ssm/aws_mock.go
+Viewed
+Original file line number 	Diff line number 	Diff line change
+@@ -0,0 +1,59 @@
+package awsssm
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+
+type mockSSMClient struct {
+	err       error
+	responses map[string]*types.Parameter
+}
+
+var (
+	mockValue    = "mock-value"
+	mockDataType = "text/plain"
+)
+
+func NewMockSSMClient() *mockSSMClient {
+	return &mockSSMClient{
+		responses: make(map[string]*types.Parameter),
+	}
+}
+
+func (m *mockSSMClient) WithResponse(name string, value string, pType types.ParameterType) *mockSSMClient {
+	m.responses[name] = &types.Parameter{
+		Value:    &value,
+		Type:     pType,
+		DataType: &mockDataType,
+	}
+	return m
+}
+
+func (m *mockSSMClient) WithError(err error) *mockSSMClient {
+	m.err = err
+	return m
+}
+
+func (m *mockSSMClient) GetParameter(ctx context.Context, params *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	if param, ok := m.responses[*params.Name]; ok {
+		return &ssm.GetParameterOutput{
+			Parameter: param,
+		}, nil
+	}
+
+	return &ssm.GetParameterOutput{
+		Parameter: &types.Parameter{
+			Value:    &mockValue,
+			Type:     types.ParameterTypeString,
+			DataType: &mockDataType,
+		},
+	}, nil
+}
+124 changes: 124 additions & 0 deletions 124
+providers/aws-ssm/aws_test.go
+Viewed
+Original file line number 	Diff line number 	Diff line change
+@@ -0,0 +1,124 @@
+package awsssm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+func TestNewAWSService(t *testing.T) {
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+
+	if err != nil {
+		t.Fatalf("Failed to load AWS config: %v", err)
+	}
+
+	aws := newAWSService(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create AWS service: %v", err)
+	}
+	if aws == nil {
+		t.Fatal("AWS service should not be nil")
+	}
+}
+
+func TestResolveBoolean(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithResponse("test", "true", types.ParameterTypeString)
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveBoolean(context.Background(), "test", false, openfeature.FlattenedContext{})
+	if !result.Value {
+		t.Errorf("Expected true, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.StaticReason {
+		t.Errorf("Expected StaticReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+
+	mockClient = NewMockSSMClient()
+	mockClient.WithResponse("test", "not-a-boolean", types.ParameterTypeString)
+
+	aws = &awsService{
+		client: mockClient,
+	}
+	result = aws.ResolveBoolean(context.Background(), "test", false, openfeature.FlattenedContext{})
+	if result.Value != false {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}
+
+func TestResolveString(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithResponse("test", "mock-value", types.ParameterTypeString)
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveString(context.Background(), "test", "default", openfeature.FlattenedContext{})
+	if result.Value != "mock-value" {
+		t.Errorf("Expected mock-value, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.StaticReason {
+		t.Errorf("Expected StaticReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+
+	mockClient = NewMockSSMClient()
+	mockClient.WithError(fmt.Errorf("mock error"))
+
+	aws = &awsService{
+		client: mockClient,
+	}
+	result = aws.ResolveString(context.Background(), "test", "default", openfeature.FlattenedContext{})
+	if result.Value != "default" {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}
+
+func TestResolveBooleanError(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithError(fmt.Errorf("mock error"))
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveBoolean(context.Background(), "test", false, openfeature.FlattenedContext{})
+	if result.Value != false {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}
+
+func TestResolveStringError(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithError(fmt.Errorf("mock error"))
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveString(context.Background(), "test", "default", openfeature.FlattenedContext{})
+	if result.Value != "default" {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}

--- a/providers/aws-ssm/aws_mock.go
+++ b/providers/aws-ssm/aws_mock.go
@@ -1,0 +1,59 @@
+package awsssm
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+
+type mockSSMClient struct {
+	err       error
+	responses map[string]*types.Parameter
+}
+
+var (
+	mockValue    = "mock-value"
+	mockDataType = "text/plain"
+)
+
+func NewMockSSMClient() *mockSSMClient {
+	return &mockSSMClient{
+		responses: make(map[string]*types.Parameter),
+	}
+}
+
+func (m *mockSSMClient) WithResponse(name string, value string, pType types.ParameterType) *mockSSMClient {
+	m.responses[name] = &types.Parameter{
+		Value:    &value,
+		Type:     pType,
+		DataType: &mockDataType,
+	}
+	return m
+}
+
+func (m *mockSSMClient) WithError(err error) *mockSSMClient {
+	m.err = err
+	return m
+}
+
+func (m *mockSSMClient) GetParameter(ctx context.Context, params *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	if param, ok := m.responses[*params.Name]; ok {
+		return &ssm.GetParameterOutput{
+			Parameter: param,
+		}, nil
+	}
+
+	return &ssm.GetParameterOutput{
+		Parameter: &types.Parameter{
+			Value:    &mockValue,
+			Type:     types.ParameterTypeString,
+			DataType: &mockDataType,
+		},
+	}, nil
+}

--- a/providers/aws-ssm/aws_test.go
+++ b/providers/aws-ssm/aws_test.go
@@ -1,0 +1,124 @@
+package awsssm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+func TestNewAWSService(t *testing.T) {
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+
+	if err != nil {
+		t.Fatalf("Failed to load AWS config: %v", err)
+	}
+
+	aws := newAWSService(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create AWS service: %v", err)
+	}
+	if aws == nil {
+		t.Fatal("AWS service should not be nil")
+	}
+}
+
+func TestResolveBoolean(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithResponse("test", "true", types.ParameterTypeString)
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveBoolean(context.Background(), "test", false, openfeature.FlattenedContext{})
+	if !result.Value {
+		t.Errorf("Expected true, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.StaticReason {
+		t.Errorf("Expected StaticReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+
+	mockClient = NewMockSSMClient()
+	mockClient.WithResponse("test", "not-a-boolean", types.ParameterTypeString)
+
+	aws = &awsService{
+		client: mockClient,
+	}
+	result = aws.ResolveBoolean(context.Background(), "test", false, openfeature.FlattenedContext{})
+	if result.Value != false {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}
+
+func TestResolveString(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithResponse("test", "mock-value", types.ParameterTypeString)
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveString(context.Background(), "test", "default", openfeature.FlattenedContext{})
+	if result.Value != "mock-value" {
+		t.Errorf("Expected mock-value, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.StaticReason {
+		t.Errorf("Expected StaticReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+
+	mockClient = NewMockSSMClient()
+	mockClient.WithError(fmt.Errorf("mock error"))
+
+	aws = &awsService{
+		client: mockClient,
+	}
+	result = aws.ResolveString(context.Background(), "test", "default", openfeature.FlattenedContext{})
+	if result.Value != "default" {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}
+
+func TestResolveBooleanError(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithError(fmt.Errorf("mock error"))
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveBoolean(context.Background(), "test", false, openfeature.FlattenedContext{})
+	if result.Value != false {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}
+
+func TestResolveStringError(t *testing.T) {
+	mockClient := NewMockSSMClient()
+	mockClient.WithError(fmt.Errorf("mock error"))
+
+	aws := &awsService{
+		client: mockClient,
+	}
+
+	result := aws.ResolveString(context.Background(), "test", "default", openfeature.FlattenedContext{})
+	if result.Value != "default" {
+		t.Errorf("Expected default value in error case, got %v", result.Value)
+	}
+	if result.ProviderResolutionDetail.Reason != openfeature.ErrorReason {
+		t.Errorf("Expected ErrorReason, got %v", result.ProviderResolutionDetail.Reason)
+	}
+}

--- a/providers/aws-ssm/go.mod
+++ b/providers/aws-ssm/go.mod
@@ -1,0 +1,3 @@
+module github.com/open-feature/go-sdk-contrib/providers/aws-ssm
+
+go 1.24.1

--- a/providers/aws-ssm/provider.go
+++ b/providers/aws-ssm/provider.go
@@ -1,0 +1,59 @@
+package awsssm
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+type Provider struct {
+	svc *awsService
+}
+
+type ProviderOption func(*Provider)
+
+
+func NewProvider(cfg aws.Config, opts ...ProviderOption) (*Provider, error) {svc := newAWSService(cfg)
+
+	return &Provider{
+		svc: svc,
+	}, nil
+}
+
+func (p *Provider) Metadata() openfeature.Metadata {
+	return openfeature.Metadata{
+		Name: "AWS System Manager Provider",
+	}
+}
+
+func (p *Provider) Hooks() []openfeature.Hook {
+	return []openfeature.Hook{}
+}
+
+
+func WithDecryption() ProviderOption {
+	return func(p *Provider) {
+		p.svc.decryption = true
+	}
+}
+
+func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+	return p.svc.ResolveBoolean(ctx, flag, defaultValue, flatCtx)
+}
+
+func (p *Provider) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+	return p.svc.ResolveString(ctx, flag, defaultValue, flatCtx)
+}
+
+func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+	return p.svc.ResolveFloat(ctx, flag, defaultValue, flatCtx)
+}
+
+func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+	return p.svc.ResolveInt(ctx, flag, defaultValue, flatCtx)
+}
+
+func (p *Provider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+	return p.svc.ResolveObject(ctx, flag, defaultValue, flatCtx)
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -155,6 +155,14 @@
       "bump-patch-for-minor-pre-major": true,
       "versioning": "default",
       "extra-files": []
+    },
+    "providers/aws-ssm": {
+      "release-type": "go",
+      "package-name": "providers/aws-ssm",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "versioning": "default",
+      "extra-files": []
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
This PR

 Implements a new server provider for AWS System Manager, matching the same implementation already present in [JS SDK](https://github.com/gdegiorgio/js-sdk-contrib/tree/main/libs/providers/aws-ssm) (See https://github.com/open-feature/js-sdk-contrib/pull/1221)