### PR TITLE
feat(aws-ssm): add interface assertion to `Provider`

### DIFF
--- a/providers/aws-ssm/provider.go
+++ b/providers/aws-ssm/provider.go
@@ -11,6 +11,8 @@ type Provider struct {
 	svc *awsService
 }
 
+var _ openfeature.FeatureProvider = (*Provider)(nil)
+
 type ProviderOption func(*Provider)
 
 func NewProvider(cfg aws.Config, opts ...ProviderOption) (*Provider, error) {


### PR DESCRIPTION
## This PR

Introduces a compile-time interface assertion to ensure that `awsssm.Provider` correctly implements the`openfeature.Provider` interface.

✅ Benefits

- Provides compile-time safety and prevents accidental interface contract violations.

🔍 Example

If `*awsssm.Provider` stops implementing `openfeature.Provider` (e.g., due to a missing method), compilation will fail with a clear message:

`*awsssm.Provider does not implement `openfeature.Provider` (missing SomeMethod method)`