### PR TITLE
fix(flagd): do not retry for certain status codes (#756)

### DIFF
--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -569,6 +569,7 @@ func createSyncProvider(cfg Configuration, log *logger.Logger) (isync.ISync, str
 		ProviderID:              cfg.ProviderID,
 		Selector:                cfg.Selector,
 		URI:                     uri,
+		RetryGracePeriod:        cfg.RetryGracePeriod,
 	}, uri
 }
 

--- a/providers/multi-provider/pkg/strategies/strategies.go
+++ b/providers/multi-provider/pkg/strategies/strategies.go
@@ -112,7 +112,7 @@ func setFlagMetadata(strategyUsed EvaluationStrategy, successProviderName string
 func cleanErrorMessage(msg string) string {
 	codeRegex := strings.Join([]string{
 		string(of.ProviderNotReadyCode),
-		// string(of.ProviderFatalCode), // TODO: not available until go-sdk 14
+		string(of.ProviderFatalCode),
 		string(of.FlagNotFoundCode),
 		string(of.ParseErrorCode),
 		string(of.TypeMismatchCode),


### PR DESCRIPTION
## This PR
This pull request enhances the gRPC synchronization logic in the `flagd` provider by introducing a mechanism to identify and handle non-retryable gRPC status codes. This ensures that certain errors (like authentication failures) are not retried unnecessarily, improving error handling and resource usage.


### Related Issues

improves #744 to fix #756 

### Notes
**Error handling improvements:**

* Added a set of non-retryable gRPC status codes (`PermissionDenied`, `Unauthenticated`) and logic to prevent retries when these errors occur during sync cycles. [[1]](diffhunk://#diff-bfa65fc1a13250019228c916bf3b306b9f5753921dae55486117948f1bdce6a6R60-R71) [[2]](diffhunk://#diff-bfa65fc1a13250019228c916bf3b306b9f5753921dae55486117948f1bdce6a6L210-R250)
* Introduced a helper function `initNonRetryableStatusCodesSet` to parse and initialize the set of non-retryable codes at startup. [[1]](diffhunk://#diff-bfa65fc1a13250019228c916bf3b306b9f5753921dae55486117948f1bdce6a6R107) [[2]](diffhunk://#diff-bfa65fc1a13250019228c916bf3b306b9f5753921dae55486117948f1bdce6a6R176-R186)

### How to test
* flagd instance with envoy filter to return PERMISSION_DENIED status code
* run go test app with flagd provider in inprocess mode, request feature flag
* Verify: instead of retrying, error is printed only once: 
<img width="1433" height="257" alt="image" src="https://github.com/user-attachments/assets/9032fc2a-a21a-49e2-bcec-f3ce5bd65e4f" />


