### PR TITLE
chore: add govulncheck to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
       - name: Run workspace init
         run: make workspace-init
+      - name: Run Vulncheck
+        run: make vulncheck
       - name: Run linter
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ lint:
 	go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOBIN}/golangci-lint run $(module)/...;)
 
+vulncheck:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+	$(foreach module, $(ALL_GO_MOD_DIRS), cd $(module) && ${GOBIN}/govulncheck ./... && cd - > /dev/null;)
+
 new-provider:
 	mkdir ./providers/$(MODULE_NAME)
 	cd ./providers/$(MODULE_NAME) && go mod init github.com/open-feature/go-sdk-contrib/providers/$(MODULE_NAME) && touch README.md


### PR DESCRIPTION
Same as https://github.com/open-feature/go-sdk/pull/462

See CI:

```
Run make vulncheck
go install golang.org/x/vuln/cmd/govulncheck@latest
go: downloading golang.org/x/vuln v1.1.4
go: downloading golang.org/x/telemetry v0.0.0-20240522233618-39ace7a40ae7
go: downloading golang.org/x/sync v0.10.0
go: downloading golang.org/x/mod v0.22.0
go: downloading golang.org/x/tools v0.29.0
cd ./hooks/open-telemetry && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./hooks/validator && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/aws-ssm && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/configcat && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/flagd && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/flagd/e2e && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/flagsmith && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/flipt && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/from-env && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/go-feature-flag && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/go-feature-flag-in-process && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/harness && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/launchdarkly && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/multi-provider && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/ofrep && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/prefab && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/rocketflag && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/statsig && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./providers/unleash && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./tests/flagd && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;  cd ./tools/flagd-http-connector && /home/runner/work/open-feature/go-sdk-contrib/bin/govulncheck ./... && cd - > /dev/null;
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.
No vulnerabilities found.

```