### PR TITLE
Add CustomHeaders option

### DIFF
--- a/providers/go-feature-flag/pkg/controller/goff_api.go
+++ b/providers/go-feature-flag/pkg/controller/goff_api.go
@@ -22,6 +22,9 @@ type GoFeatureFlagApiOptions struct {
 	// (This feature is available only if you are using GO Feature Flag relay proxy v1.7.0 or above)
 	// Default: null
 	APIKey string
+	// CustomHeaders (optional) allows setting custom headers for every HTTP request.
+	// Default: null
+	CustomHeaders map[string]string
 	// ExporterMetadata (optional) If we set metadata, it will be sent with every data collection requests along with the events.
 	ExporterMetadata map[string]any
 }
@@ -61,6 +64,9 @@ func (g *GoFeatureFlagAPI) CollectData(events []model.FeatureEvent) error {
 	if g.options.APIKey != "" {
 		req.Header.Set(AuthorizationHeader, BearerPrefix+g.options.APIKey)
 	}
+	for k, v := range g.options.CustomHeaders {
+		req.Header.Set(k, v)
+	}
 
 	response, err := g.getHttpClient().Do(req)
 	if err != nil {
@@ -86,6 +92,9 @@ func (g *GoFeatureFlagAPI) ConfigurationHasChanged() (ConfigurationChangeStatus,
 	req.Header.Set(ContentTypeHeader, ApplicationJson)
 	if g.options.APIKey != "" {
 		req.Header.Set(AuthorizationHeader, BearerPrefix+g.options.APIKey)
+	}
+	for k, v := range g.options.CustomHeaders {
+		req.Header.Set(k, v)
 	}
 	if g.configChangeEtag != "" {
 		req.Header.Set(IfNoneMatchHeader, g.configChangeEtag)

--- a/providers/go-feature-flag/pkg/controller/goff_api_test.go
+++ b/providers/go-feature-flag/pkg/controller/goff_api_test.go
@@ -30,6 +30,7 @@ func Test_CollectDataAPI(t *testing.T) {
 			options: controller.GoFeatureFlagApiOptions{
 				Endpoint:         "http://localhost:1031",
 				APIKey:           "",
+				CustomHeaders:    map[string]string{"User-Agent": "goff-sdk-tests"},
 				ExporterMetadata: map[string]any{"openfeature": true, "provider": "go"},
 			},
 			events: []model.FeatureEvent{
@@ -67,6 +68,7 @@ func Test_CollectDataAPI(t *testing.T) {
 			wantHeaders: func() http.Header {
 				headers := http.Header{}
 				headers.Set(controller.ContentTypeHeader, controller.ApplicationJson)
+				headers.Set("User-Agent", "goff-sdk-tests")
 				return headers
 			}(),
 			wantReqBody: "{\"events\":[{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"ABCD\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"},{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"EFGH\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"}],\"meta\":{\"openfeature\":true,\"provider\":\"go\"}}",
@@ -77,6 +79,7 @@ func Test_CollectDataAPI(t *testing.T) {
 			options: controller.GoFeatureFlagApiOptions{
 				Endpoint:         "http://localhost:1031",
 				APIKey:           "my-key",
+				CustomHeaders:    map[string]string{"User-Agent": "goff-sdk-tests"},
 				ExporterMetadata: map[string]any{"openfeature": true, "provider": "go"},
 			},
 			events: []model.FeatureEvent{
@@ -115,6 +118,7 @@ func Test_CollectDataAPI(t *testing.T) {
 				headers := http.Header{}
 				headers.Set(controller.ContentTypeHeader, controller.ApplicationJson)
 				headers.Set(controller.AuthorizationHeader, controller.BearerPrefix+"my-key")
+				headers.Set("User-Agent", "goff-sdk-tests")
 				return headers
 			}(),
 			wantReqBody: "{\"events\":[{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"ABCD\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"},{\"kind\":\"feature\",\"contextKind\":\"user\",\"userKey\":\"EFGH\",\"creationDate\":1722266324,\"key\":\"random-key\",\"variation\":\"variationA\",\"value\":\"YO\",\"default\":false,\"version\":\"\",\"source\":\"SERVER\"}],\"meta\":{\"openfeature\":true,\"provider\":\"go\"}}",
@@ -181,13 +185,15 @@ func Test_ConfigurationHasChanged(t *testing.T) {
 		}}
 		client := &http.Client{Transport: &mrt}
 		options := controller.GoFeatureFlagApiOptions{
-			Endpoint:   "http://localhost:1031",
-			HTTPClient: client,
+			Endpoint:      "http://localhost:1031",
+			HTTPClient:    client,
+			CustomHeaders: map[string]string{"User-Agent": "goff-sdk-tests"},
 		}
 		g := controller.NewGoFeatureFlagAPI(options)
 		status, err := g.ConfigurationHasChanged()
 		require.NoError(t, err)
 		assert.Equal(t, controller.FlagConfigurationInitialized, status)
+		assert.Equal(t, "goff-sdk-tests", mrt.GetLastRequest().Header.Get("User-Agent"))
 	})
 
 	t.Run("Change in the configuration", func(t *testing.T) {

--- a/providers/go-feature-flag/pkg/provider.go
+++ b/providers/go-feature-flag/pkg/provider.go
@@ -51,6 +51,12 @@ func NewProviderWithContext(ctx context.Context, options ProviderOptions) (*Prov
 	ofrepOptions = append(ofrepOptions, ofrep.WithHeaderProvider(func() (key string, value string) {
 		return controller.ContentTypeHeader, controller.ApplicationJson
 	}))
+	for k, v := range options.CustomHeaders {
+		scopedK, scopedV := k, v
+		ofrepOptions = append(ofrepOptions, ofrep.WithHeaderProvider(func() (key string, value string) {
+			return scopedK, scopedV
+		}))
+	}
 	ofrepProvider := ofrep.NewProvider(options.Endpoint, ofrepOptions...)
 	cacheCtrl := controller.NewCache(options.FlagCacheSize, options.FlagCacheTTL, options.DisableCache)
 
@@ -65,6 +71,7 @@ func NewProviderWithContext(ctx context.Context, options ProviderOptions) (*Prov
 		Endpoint:         options.Endpoint,
 		HTTPClient:       options.HTTPClient,
 		APIKey:           options.APIKey,
+		CustomHeaders:    options.CustomHeaders,
 		ExporterMetadata: options.ExporterMetadata,
 	})
 	dataCollectorManager := controller.NewDataCollectorManager(

--- a/providers/go-feature-flag/pkg/provider_options.go
+++ b/providers/go-feature-flag/pkg/provider_options.go
@@ -24,6 +24,9 @@ type ProviderOptions struct {
 	// Default: null
 	APIKey string
 
+	// CustomHeaders (optional) allows setting custom headers for every HTTP request.
+	CustomHeaders map[string]string
+
 	// DisableCache (optional) set to true if you would like that every flag evaluation goes to the GO Feature Flag directly.
 	DisableCache bool
 


### PR DESCRIPTION
## This PR
Adds support for custom headers for every HTTP request, similar to the [option found on the Ruby SDK](https://github.com/open-feature/ruby-sdk-contrib/blob/413cfd8f65e62dc14bd514001e32f1b140dcdf3e/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/options.rb#L16). Custom headers can be used to define a `User-Agent`, to prevent requests from being blocked by servers that require browser-like identification or specific device signatures.

### Notes
Our WAF requires the `User-Agent` header to be defined. Requests to the relay-proxy are being denied because the header is not specified.
