### PR TITLE
feat(go-feature-flag): Add in-process evaluation support

### DIFF
--- a/providers/go-feature-flag/pkg/eval_request.go
+++ b/providers/go-feature-flag/pkg/eval_request.go
@@ -1,0 +1,54 @@
+package gofeatureflag
+
+import (
+	of "github.com/open-feature/go-sdk/openfeature"
+)
+
+const targetingKey = "targetingKey"
+
+func NewEvalFlagRequest[T JsonType](flatCtx of.FlattenedContext, defaultValue T) (EvalFlagRequest, *of.ResolutionError) {
+	if _, ok := flatCtx[targetingKey]; !ok {
+		err := of.NewTargetingKeyMissingResolutionError("no targetingKey provided in the evaluation context")
+		return EvalFlagRequest{}, &err
+	}
+	targetingKeyVal, ok := flatCtx[targetingKey].(string)
+	if !ok {
+		err := of.NewTargetingKeyMissingResolutionError("targetingKey field MUST be a string")
+		return EvalFlagRequest{}, &err
+	}
+
+	anonymous := true
+	if val, ok := flatCtx["anonymous"].(bool); ok {
+		anonymous = val
+	}
+
+	return EvalFlagRequest{
+		User: &UserRequest{
+			Key:       targetingKeyVal,
+			Anonymous: anonymous,
+			Custom:    flatCtx,
+		},
+		EvaluationContext: &EvaluationContextRequest{
+			Key:    targetingKeyVal,
+			Custom: flatCtx,
+		},
+		DefaultValue: defaultValue,
+	}, nil
+}
+
+type EvalFlagRequest struct {
+	User              *UserRequest              `json:"user" xml:"user" form:"user" query:"user"`
+	EvaluationContext *EvaluationContextRequest `json:"evaluationContext,omitempty" xml:"evaluationContext,omitempty" form:"evaluationContext,omitempty" query:"evaluationContext,omitempty"`
+	DefaultValue      any                       `json:"defaultValue" xml:"defaultValue" form:"defaultValue" query:"defaultValue"`
+}
+
+type UserRequest struct {
+	Key       string         `json:"key" xml:"key" form:"key" query:"key" example:"08b5ffb7-7109-42f4-a6f2-b85560fbd20f"`
+	Anonymous bool           `json:"anonymous" xml:"anonymous" form:"anonymous" query:"anonymous" example:"false"`
+	Custom    map[string]any `json:"custom" xml:"custom" form:"custom" query:"custom" swaggertype:"object,string" example:"email:contact@gofeatureflag.org,firstname:John,lastname:Doe,company:GO Feature Flag"`
+}
+
+type EvaluationContextRequest struct {
+	Key    string         `json:"key" xml:"key" form:"key" query:"key" example:"08b5ffb7-7109-42f4-a6f2-b85560fbd20f"`
+	Custom map[string]any `json:"custom" xml:"custom" form:"custom" query:"custom" swaggertype:"object,string" example:"email:contact@gofeatureflag.org,firstname:John,lastname:Doe,company:GO Feature Flag"`
+}

--- a/providers/go-feature-flag/pkg/generic_evaluation_detail.go
+++ b/providers/go-feature-flag/pkg/generic_evaluation_detail.go
@@ -1,0 +1,8 @@
+package gofeatureflag
+
+import of "github.com/open-feature/go-sdk/openfeature"
+
+type GenericResolutionDetail[T JsonType] struct {
+	Value T
+	of.ProviderResolutionDetail
+}

--- a/providers/go-feature-flag/pkg/json_type.go
+++ b/providers/go-feature-flag/pkg/json_type.go
@@ -1,0 +1,3 @@
+package gofeatureflag
+
+type JsonType = any

--- a/providers/go-feature-flag/pkg/provider.go
+++ b/providers/go-feature-flag/pkg/provider.go
@@ -10,20 +10,24 @@ import (
 	"github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/pkg/util"
 	"github.com/open-feature/go-sdk-contrib/providers/ofrep"
 	of "github.com/open-feature/go-sdk/openfeature"
+	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 )
 
 const providerName = "GO Feature Flag"
 const cacheableMetadataKey = "gofeatureflag_cacheable"
 
 type Provider struct {
-	ofrepProvider        *ofrep.Provider
-	cache                *controller.Cache
-	dataCollectorManager controller.DataCollectorManager
-	options              ProviderOptions
-	status               of.State
-	hooks                []of.Hook
-	goffAPI              controller.GoFeatureFlagAPI
-	pollingInfo          struct {
+	ofrepProvider         *ofrep.Provider
+	cache                 *controller.Cache
+	dataCollectorManager  controller.DataCollectorManager
+	options               ProviderOptions
+	status                of.State
+	hooks                 []of.Hook
+	goffAPI               controller.GoFeatureFlagAPI
+	evaluationType        EvaluationType
+	goFeatureFlagInstance *ffclient.GoFeatureFlag
+	pollingInfo           struct {
 		ticker  *time.Ticker
 		channel chan bool
 	}
@@ -41,20 +45,29 @@ func NewProviderWithContext(ctx context.Context, options ProviderOptions) (*Prov
 	if err := options.Validation(); err != nil {
 		return nil, err
 	}
-	ofrepOptions := make([]ofrep.Option, 0)
-	if options.APIKey != "" {
-		ofrepOptions = append(ofrepOptions, ofrep.WithBearerToken(options.APIKey))
-	}
-	if options.HTTPClient != nil {
-		ofrepOptions = append(ofrepOptions, ofrep.WithClient(options.HTTPClient))
-	}
-	ofrepOptions = append(ofrepOptions, ofrep.WithHeaderProvider(func() (key string, value string) {
-		return controller.ContentTypeHeader, controller.ApplicationJson
-	}))
-	ofrepProvider := ofrep.NewProvider(options.Endpoint, ofrepOptions...)
-	cacheCtrl := controller.NewCache(options.FlagCacheSize, options.FlagCacheTTL, options.DisableCache)
 
-	// Adding metadata to the GO Feature Flag provider to be sent to the exporter
+	if options.EvaluationType == "" {
+		options.EvaluationType = EvaluationTypeInProcess
+	}
+
+	var ofrepProvider *ofrep.Provider
+	var cacheCtrl *controller.Cache
+
+	if options.EvaluationType == EvaluationTypeRemote {
+		ofrepOptions := make([]ofrep.Option, 0)
+		if options.APIKey != "" {
+			ofrepOptions = append(ofrepOptions, ofrep.WithBearerToken(options.APIKey))
+		}
+		if options.HTTPClient != nil {
+			ofrepOptions = append(ofrepOptions, ofrep.WithClient(options.HTTPClient))
+		}
+		ofrepOptions = append(ofrepOptions, ofrep.WithHeaderProvider(func() (key string, value string) {
+			return controller.ContentTypeHeader, controller.ApplicationJson
+		}))
+		ofrepProvider = ofrep.NewProvider(options.Endpoint, ofrepOptions...)
+		cacheCtrl = controller.NewCache(options.FlagCacheSize, options.FlagCacheTTL, options.DisableCache)
+	}
+
 	if options.ExporterMetadata == nil {
 		options.ExporterMetadata = make(map[string]any)
 	}
@@ -72,14 +85,26 @@ func NewProviderWithContext(ctx context.Context, options ProviderOptions) (*Prov
 		options.DataCollectorMaxEventStored,
 		options.DataFlushInterval,
 	)
+
+	var goFeatureFlagInstance *ffclient.GoFeatureFlag
+	if options.EvaluationType == EvaluationTypeInProcess {
+		goff, err := ffclient.New(*options.GOFeatureFlagConfig)
+		if err != nil {
+			return nil, err
+		}
+		goFeatureFlagInstance = goff
+	}
+
 	return &Provider{
-		ofrepProvider:        ofrepProvider,
-		cache:                cacheCtrl,
-		dataCollectorManager: dataCollectorManager,
-		options:              options,
-		goffAPI:              goffAPI,
-		events:               make(chan of.Event, 5),
-		hooks:                []of.Hook{},
+		ofrepProvider:         ofrepProvider,
+		cache:                 cacheCtrl,
+		dataCollectorManager:  dataCollectorManager,
+		options:               options,
+		goffAPI:               goffAPI,
+		evaluationType:        options.EvaluationType,
+		goFeatureFlagInstance: goFeatureFlagInstance,
+		events:                make(chan of.Event, 5),
+		hooks:                 []of.Hook{},
 	}, nil
 }
 
@@ -96,6 +121,11 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVa
 			ProviderResolutionDetail: of.ProviderResolutionDetail{ResolutionError: *err, Reason: of.ErrorReason},
 		}
 	}
+
+	if p.evaluationType == EvaluationTypeInProcess {
+		return p.booleanEvaluationInProcess(ctx, flag, defaultValue, evalCtx)
+	}
+
 	if cacheValue, err := p.cache.GetBool(flag, evalCtx); err == nil && cacheValue != nil {
 		cacheValue.Reason = of.CachedReason
 		return *cacheValue
@@ -114,6 +144,11 @@ func (p *Provider) StringEvaluation(ctx context.Context, flag string, defaultVal
 			ProviderResolutionDetail: of.ProviderResolutionDetail{ResolutionError: *err, Reason: of.ErrorReason},
 		}
 	}
+
+	if p.evaluationType == EvaluationTypeInProcess {
+		return p.stringEvaluationInProcess(ctx, flag, defaultValue, evalCtx)
+	}
+
 	if cacheValue, err := p.cache.GetString(flag, evalCtx); err == nil && cacheValue != nil {
 		cacheValue.Reason = of.CachedReason
 		return *cacheValue
@@ -132,6 +167,11 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValu
 			ProviderResolutionDetail: of.ProviderResolutionDetail{ResolutionError: *err, Reason: of.ErrorReason},
 		}
 	}
+
+	if p.evaluationType == EvaluationTypeInProcess {
+		return p.floatEvaluationInProcess(ctx, flag, defaultValue, evalCtx)
+	}
+
 	if cacheValue, err := p.cache.GetFloat(flag, evalCtx); err == nil && cacheValue != nil {
 		cacheValue.Reason = of.CachedReason
 		return *cacheValue
@@ -150,6 +190,11 @@ func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue 
 			ProviderResolutionDetail: of.ProviderResolutionDetail{ResolutionError: *err, Reason: of.ErrorReason},
 		}
 	}
+
+	if p.evaluationType == EvaluationTypeInProcess {
+		return p.intEvaluationInProcess(ctx, flag, defaultValue, evalCtx)
+	}
+
 	if cacheValue, err := p.cache.GetInt(flag, evalCtx); err == nil && cacheValue != nil {
 		cacheValue.Reason = of.CachedReason
 		return *cacheValue
@@ -168,6 +213,11 @@ func (p *Provider) ObjectEvaluation(ctx context.Context, flag string, defaultVal
 			ProviderResolutionDetail: of.ProviderResolutionDetail{ResolutionError: *err, Reason: of.ErrorReason},
 		}
 	}
+
+	if p.evaluationType == EvaluationTypeInProcess {
+		return p.objectEvaluationInProcess(ctx, flag, defaultValue, evalCtx)
+	}
+
 	if cacheValue, err := p.cache.GetInterface(flag, evalCtx); err == nil && cacheValue != nil {
 		cacheValue.Reason = of.CachedReason
 		return *cacheValue
@@ -193,8 +243,12 @@ func (p *Provider) Init(_ of.EvaluationContext) error {
 	}
 
 	// Start polling to check if there is any flag change in order to invalidate the cache.
-	if p.options.FlagChangePollingInterval >= 0 && !p.options.DisableCache {
-		p.startPolling(p.options.FlagChangePollingInterval)
+	if p.options.FlagChangePollingInterval >= 0 {
+		if p.evaluationType == EvaluationTypeRemote && !p.options.DisableCache {
+			p.startPolling(p.options.FlagChangePollingInterval)
+		} else if p.evaluationType == EvaluationTypeInProcess {
+			p.startInProcessPolling(p.options.FlagChangePollingInterval)
+		}
 	}
 
 	p.status = of.ReadyState
@@ -216,6 +270,9 @@ func (p *Provider) Shutdown() {
 		p.dataCollectorManager.Stop()
 	}
 	p.stopPolling()
+	if p.evaluationType == EvaluationTypeInProcess && p.goFeatureFlagInstance != nil {
+		p.goFeatureFlagInstance.Close()
+	}
 }
 
 // EventChannel returns the event channel of this provider
@@ -273,5 +330,187 @@ func (p *Provider) stopPolling() {
 	}
 	if p.pollingInfo.ticker != nil {
 		p.pollingInfo.ticker.Stop()
+	}
+}
+
+// startInProcessPolling starts the polling mechanism for in-process mode to check if the configuration has changed.
+func (p *Provider) startInProcessPolling(pollingInterval time.Duration) {
+	if pollingInterval == 0 {
+		pollingInterval = 120000 * time.Millisecond
+	}
+	p.pollingInfo = struct {
+		ticker  *time.Ticker
+		channel chan bool
+	}{
+		ticker:  time.NewTicker(pollingInterval),
+		channel: make(chan bool),
+	}
+	go func() {
+		for {
+			select {
+			case <-p.pollingInfo.channel:
+				return
+			case <-p.pollingInfo.ticker.C:
+				// For in-process mode, we rely on the GO Feature Flag module's internal polling
+				// We emit a configuration change event to notify users of potential updates
+				if p.goFeatureFlagInstance != nil {
+					p.events <- of.Event{
+						ProviderName: providerName, EventType: of.ProviderConfigChange,
+						ProviderEventDetails: of.ProviderEventDetails{Message: "Configuration check completed (in-process mode)"}}
+				}
+			}
+		}
+	}()
+}
+
+func (p *Provider) booleanEvaluationInProcess(ctx context.Context, flagName string, defaultValue bool, evalCtx of.FlattenedContext) of.BoolResolutionDetail {
+	res := evaluateLocally[bool](p, flagName, defaultValue, evalCtx)
+	return of.BoolResolutionDetail{
+		Value:                    res.Value,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+func (p *Provider) stringEvaluationInProcess(ctx context.Context, flagName string, defaultValue string, evalCtx of.FlattenedContext) of.StringResolutionDetail {
+	res := evaluateLocally[string](p, flagName, defaultValue, evalCtx)
+	return of.StringResolutionDetail{
+		Value:                    res.Value,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+func (p *Provider) floatEvaluationInProcess(ctx context.Context, flagName string, defaultValue float64, evalCtx of.FlattenedContext) of.FloatResolutionDetail {
+	res := evaluateLocally[float64](p, flagName, defaultValue, evalCtx)
+	return of.FloatResolutionDetail{
+		Value:                    res.Value,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+func (p *Provider) intEvaluationInProcess(ctx context.Context, flagName string, defaultValue int64, evalCtx of.FlattenedContext) of.IntResolutionDetail {
+	res := evaluateLocally[int64](p, flagName, defaultValue, evalCtx)
+	return of.IntResolutionDetail{
+		Value:                    res.Value,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+func (p *Provider) objectEvaluationInProcess(ctx context.Context, flagName string, defaultValue any, evalCtx of.FlattenedContext) of.InterfaceResolutionDetail {
+	res := evaluateLocally[any](p, flagName, defaultValue, evalCtx)
+	return of.InterfaceResolutionDetail{
+		Value:                    res.Value,
+		ProviderResolutionDetail: res.ProviderResolutionDetail,
+	}
+}
+
+func evaluateLocally[T JsonType](provider *Provider, flagName string, defaultValue T, evalCtx of.FlattenedContext) GenericResolutionDetail[T] {
+	goffRequestBody, errConvert := NewEvalFlagRequest[T](evalCtx, defaultValue)
+	if errConvert != nil {
+		return GenericResolutionDetail[T]{
+			Value: defaultValue,
+			ProviderResolutionDetail: of.ProviderResolutionDetail{
+				ResolutionError: *errConvert,
+				Reason:          of.ErrorReason,
+			},
+		}
+	}
+
+	ctxBuilder := ffcontext.NewEvaluationContextBuilder(goffRequestBody.EvaluationContext.Key)
+	for k, v := range goffRequestBody.EvaluationContext.Custom {
+		ctxBuilder.AddCustom(k, v)
+	}
+
+	rawResult, err := provider.goFeatureFlagInstance.RawVariation(flagName, ctxBuilder.Build(), defaultValue)
+	if err != nil {
+		return GenericResolutionDetail[T]{
+			Value: defaultValue,
+			ProviderResolutionDetail: of.ProviderResolutionDetail{
+				ResolutionError: of.NewGeneralResolutionError(err.Error()),
+				Reason:          of.ErrorReason,
+			},
+		}
+	}
+
+	if rawResult.ErrorCode != "" {
+		switch rawResult.ErrorCode {
+		case string(of.FlagNotFoundCode):
+			return GenericResolutionDetail[T]{
+				Value: defaultValue,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					ResolutionError: of.NewFlagNotFoundResolutionError(fmt.Sprintf("flag %s was not found in GO Feature Flag", flagName)),
+					Reason:          of.ErrorReason,
+				},
+			}
+		case string(of.ProviderNotReadyCode):
+			return GenericResolutionDetail[T]{
+				Value: defaultValue,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					ResolutionError: of.NewProviderNotReadyResolutionError(
+						fmt.Sprintf("provider not ready for evaluation of flag %s", flagName)),
+					Reason: of.ErrorReason,
+				},
+			}
+		case string(of.ParseErrorCode):
+			return GenericResolutionDetail[T]{
+				Value: defaultValue,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					ResolutionError: of.NewParseErrorResolutionError(
+						fmt.Sprintf("parse error during evaluation of flag %s", flagName)),
+					Reason: of.ErrorReason,
+				},
+			}
+		case string(of.TypeMismatchCode):
+			return GenericResolutionDetail[T]{
+				Value: defaultValue,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					ResolutionError: of.NewTypeMismatchResolutionError(
+						fmt.Sprintf("unexpected type for flag %s", flagName)),
+					Reason: of.ErrorReason,
+				},
+			}
+		case string(of.GeneralCode):
+			return GenericResolutionDetail[T]{
+				Value: defaultValue,
+				ProviderResolutionDetail: of.ProviderResolutionDetail{
+					ResolutionError: of.NewGeneralResolutionError(
+						fmt.Sprintf("unexpected error during evaluation of the flag %s", flagName)),
+					Reason: of.ErrorReason,
+				},
+			}
+		}
+	}
+
+	var v JsonType
+	switch value := rawResult.Value.(type) {
+	case int:
+		v = int64(value)
+	default:
+		v = value
+	}
+
+	switch value := v.(type) {
+	case nil:
+		return GenericResolutionDetail[T]{
+			ProviderResolutionDetail: of.ProviderResolutionDetail{
+				Reason:  of.Reason(rawResult.Reason),
+				Variant: rawResult.VariationType,
+			},
+		}
+	case T:
+		return GenericResolutionDetail[T]{
+			Value: value,
+			ProviderResolutionDetail: of.ProviderResolutionDetail{
+				Reason:  of.Reason(rawResult.Reason),
+				Variant: rawResult.VariationType,
+			},
+		}
+	default:
+		return GenericResolutionDetail[T]{
+			Value: defaultValue,
+			ProviderResolutionDetail: of.ProviderResolutionDetail{
+				ResolutionError: of.NewTypeMismatchResolutionError(fmt.Sprintf("unexpected type for flag %s", flagName)),
+				Reason:          of.ErrorReason,
+			},
+		}
 	}
 }

--- a/providers/go-feature-flag/pkg/provider_test.go
+++ b/providers/go-feature-flag/pkg/provider_test.go
@@ -323,9 +323,10 @@ func TestProvider_BooleanEvaluation(t *testing.T) {
 		cli := mockClient{}
 		t.Run(tt.name, func(t *testing.T) {
 			options := gofeatureflag.ProviderOptions{
-				Endpoint:     "https://gofeatureflag.org/",
-				HTTPClient:   NewMockClient(cli.roundTripFunc),
-				DisableCache: true,
+				Endpoint:       "https://gofeatureflag.org/",
+				EvaluationType: gofeatureflag.EvaluationTypeRemote,
+				HTTPClient:     NewMockClient(cli.roundTripFunc),
+				DisableCache:   true,
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
@@ -451,9 +452,10 @@ func TestProvider_StringEvaluation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cli := mockClient{}
 			options := gofeatureflag.ProviderOptions{
-				Endpoint:     "https://gofeatureflag.org/",
-				HTTPClient:   NewMockClient(cli.roundTripFunc),
-				DisableCache: true,
+				Endpoint:       "https://gofeatureflag.org/",
+				EvaluationType: gofeatureflag.EvaluationTypeRemote,
+				HTTPClient:     NewMockClient(cli.roundTripFunc),
+				DisableCache:   true,
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
@@ -580,9 +582,10 @@ func TestProvider_FloatEvaluation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cli := mockClient{}
 			options := gofeatureflag.ProviderOptions{
-				Endpoint:     "https://gofeatureflag.org/",
-				HTTPClient:   NewMockClient(cli.roundTripFunc),
-				DisableCache: true,
+				Endpoint:       "https://gofeatureflag.org/",
+				EvaluationType: gofeatureflag.EvaluationTypeRemote,
+				HTTPClient:     NewMockClient(cli.roundTripFunc),
+				DisableCache:   true,
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
@@ -709,9 +712,10 @@ func TestProvider_IntEvaluation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cli := mockClient{}
 			options := gofeatureflag.ProviderOptions{
-				Endpoint:     "https://gofeatureflag.org/",
-				HTTPClient:   NewMockClient(cli.roundTripFunc),
-				DisableCache: true,
+				Endpoint:       "https://gofeatureflag.org/",
+				EvaluationType: gofeatureflag.EvaluationTypeRemote,
+				HTTPClient:     NewMockClient(cli.roundTripFunc),
+				DisableCache:   true,
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
@@ -822,9 +826,10 @@ func TestProvider_ObjectEvaluation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cli := mockClient{}
 			options := gofeatureflag.ProviderOptions{
-				Endpoint:     "https://gofeatureflag.org/",
-				HTTPClient:   NewMockClient(cli.roundTripFunc),
-				DisableCache: true,
+				Endpoint:       "https://gofeatureflag.org/",
+				EvaluationType: gofeatureflag.EvaluationTypeRemote,
+				HTTPClient:     NewMockClient(cli.roundTripFunc),
+				DisableCache:   true,
 			}
 			provider, err := gofeatureflag.NewProvider(options)
 			assert.NoError(t, err)
@@ -851,11 +856,12 @@ func TestProvider_Cache(t *testing.T) {
 	t.Run("Call flag multiple times with the same user", func(t *testing.T) {
 		cli := mockClient{}
 		options := gofeatureflag.ProviderOptions{
-			Endpoint:      "https://gofeatureflag.org/",
-			HTTPClient:    NewMockClient(cli.roundTripFunc),
-			DisableCache:  false,
-			FlagCacheTTL:  5 * time.Minute,
-			FlagCacheSize: 5,
+			Endpoint:       "https://gofeatureflag.org/",
+			EvaluationType: gofeatureflag.EvaluationTypeRemote,
+			HTTPClient:     NewMockClient(cli.roundTripFunc),
+			DisableCache:   false,
+			FlagCacheTTL:   5 * time.Minute,
+			FlagCacheSize:  5,
 		}
 
 		provider, err := gofeatureflag.NewProvider(options)
@@ -883,11 +889,12 @@ func TestProvider_Cache(t *testing.T) {
 	t.Run("Call flag multiple times with different evaluation context", func(t *testing.T) {
 		cli := mockClient{}
 		options := gofeatureflag.ProviderOptions{
-			Endpoint:      "https://gofeatureflag.org/",
-			HTTPClient:    NewMockClient(cli.roundTripFunc),
-			DisableCache:  false,
-			FlagCacheTTL:  5 * time.Minute,
-			FlagCacheSize: 5,
+			Endpoint:       "https://gofeatureflag.org/",
+			EvaluationType: gofeatureflag.EvaluationTypeRemote,
+			HTTPClient:     NewMockClient(cli.roundTripFunc),
+			DisableCache:   false,
+			FlagCacheTTL:   5 * time.Minute,
+			FlagCacheSize:  5,
 		}
 
 		provider, err := gofeatureflag.NewProvider(options)
@@ -919,11 +926,12 @@ func TestProvider_Cache(t *testing.T) {
 	t.Run("Cache fill all cache", func(t *testing.T) {
 		mockedHttpClient := mockClient{}
 		options := gofeatureflag.ProviderOptions{
-			Endpoint:      "https://gofeatureflag.org/",
-			HTTPClient:    NewMockClient(mockedHttpClient.roundTripFunc),
-			DisableCache:  false,
-			FlagCacheTTL:  5 * time.Minute,
-			FlagCacheSize: 2,
+			Endpoint:       "https://gofeatureflag.org/",
+			EvaluationType: gofeatureflag.EvaluationTypeRemote,
+			HTTPClient:     NewMockClient(mockedHttpClient.roundTripFunc),
+			DisableCache:   false,
+			FlagCacheTTL:   5 * time.Minute,
+			FlagCacheSize:  2,
 		}
 
 		provider, err := gofeatureflag.NewProvider(options)
@@ -963,11 +971,12 @@ func TestProvider_Cache(t *testing.T) {
 	t.Run("Cache TTL reached", func(t *testing.T) {
 		mockedHttpClient := mockClient{}
 		options := gofeatureflag.ProviderOptions{
-			Endpoint:      "https://gofeatureflag.org/",
-			HTTPClient:    NewMockClient(mockedHttpClient.roundTripFunc),
-			DisableCache:  false,
-			FlagCacheTTL:  500 * time.Millisecond,
-			FlagCacheSize: 200,
+			Endpoint:       "https://gofeatureflag.org/",
+			EvaluationType: gofeatureflag.EvaluationTypeRemote,
+			HTTPClient:     NewMockClient(mockedHttpClient.roundTripFunc),
+			DisableCache:   false,
+			FlagCacheTTL:   500 * time.Millisecond,
+			FlagCacheSize:  200,
 		}
 
 		provider, err := gofeatureflag.NewProvider(options)
@@ -991,6 +1000,7 @@ func TestProvider_DataCollectorHook(t *testing.T) {
 		cli := mockClient{}
 		options := gofeatureflag.ProviderOptions{
 			Endpoint:             "https://gofeatureflag.org/",
+			EvaluationType:       gofeatureflag.EvaluationTypeRemote,
 			HTTPClient:           NewMockClient(cli.roundTripFunc),
 			DisableCache:         false,
 			DataFlushInterval:    100 * time.Millisecond,
@@ -1034,6 +1044,7 @@ func TestProvider_DataCollectorHook(t *testing.T) {
 		cli := mockClient{}
 		options := gofeatureflag.ProviderOptions{
 			Endpoint:             "https://gofeatureflag.org/",
+			EvaluationType:       gofeatureflag.EvaluationTypeRemote,
 			HTTPClient:           NewMockClient(cli.roundTripFunc),
 			DisableCache:         false,
 			DataFlushInterval:    100 * time.Millisecond,
@@ -1059,6 +1070,7 @@ func TestProvider_FlagChangePolling(t *testing.T) {
 		cli := mockClient{}
 		options := gofeatureflag.ProviderOptions{
 			Endpoint:                  "https://gofeatureflag.org/",
+			EvaluationType:            gofeatureflag.EvaluationTypeRemote,
 			HTTPClient:                NewMockClient(cli.roundTripFunc),
 			DisableCache:              false,
 			FlagCacheTTL:              10 * time.Minute,
@@ -1124,6 +1136,7 @@ func TestProvider_EvaluationEnrichmentHook(t *testing.T) {
 			cli := mockClient{}
 			options := gofeatureflag.ProviderOptions{
 				Endpoint:         "https://gofeatureflag.org/",
+				EvaluationType:   gofeatureflag.EvaluationTypeRemote,
 				HTTPClient:       NewMockClient(cli.roundTripFunc),
 				ExporterMetadata: tt.exporterMetadata,
 			}


### PR DESCRIPTION
This PR adds in-process evaluation support to the GO Feature Flag provider, unifying the functionality from both go-feature-flag and go-feature-flag-in-process providers into a single package.

- Add EvaluationType configuration option (InProcess/Remote)
- Implement in-process evaluation using ffclient integration
- Add GOFeatureFlagConfig and EvaluationFlagList fields
- Support configuration polling for both evaluation modes
- Update tests to use EvaluationTypeRemote

Related Issues
Related: thomaspoignant/go-feature-flag#4601

 Notes
- Default evaluation type changed to InProcess (breaking change)
- Users can maintain existing behavior by explicitly setting EvaluationType: Remote
- Aligns GO provider with Java, .NET, and Node.js providers