### PR TITLE
fix(flagd): prevent goroutine leaks in event handling on shutdown

### DIFF
--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -24,7 +24,9 @@ type Provider struct {
 	status                of.State
 	mtx                   parallel.RWMutex
 
-	eventStream chan of.Event
+	shutdownChan chan struct{}
+	shutdownOnce parallel.Once
+	eventStream  chan of.Event
 }
 
 func NewProvider(opts ...ProviderOption) (*Provider, error) {
@@ -36,6 +38,7 @@ func NewProvider(opts ...ProviderOption) (*Provider, error) {
 
 	provider := &Provider{
 		initialized:           false,
+		shutdownChan:          make(chan struct{}),
 		eventStream:           make(chan of.Event),
 		providerConfiguration: providerConfiguration,
 		status:                of.NotReadyState,
@@ -147,16 +150,30 @@ func (p *Provider) Init(_ of.EvaluationContext) error {
 	}
 }
 
-// handleEvents runs in a separate goroutine and processes events from the service
+// handleEvents runs in a separate goroutine and processes events from the service.
+// It exits when the service event channel closes (on Shutdown) or the shutdownChan
+// is closed, ensuring the goroutine is never leaked.
 func (p *Provider) handleEvents() {
 	serviceEventChan := p.service.EventChannel()
-	for event := range serviceEventChan {
-		p.eventStream <- event
-		switch event.EventType {
-		case of.ProviderReady, of.ProviderConfigChange:
-			p.setStatus(of.ReadyState)
-		case of.ProviderError:
-			p.setStatus(of.ErrorState)
+	for {
+		select {
+		case event, ok := <-serviceEventChan:
+			if !ok {
+				return
+			}
+			select {
+			case p.eventStream <- event:
+			case <-p.shutdownChan:
+				return
+			}
+			switch event.EventType {
+			case of.ProviderReady, of.ProviderConfigChange:
+				p.setStatus(of.ReadyState)
+			case of.ProviderError:
+				p.setStatus(of.ErrorState)
+			}
+		case <-p.shutdownChan:
+			return
 		}
 	}
 }
@@ -172,6 +189,9 @@ func (p *Provider) Shutdown() {
 	defer p.mtx.Unlock()
 
 	p.initialized = false
+	p.shutdownOnce.Do(func() {
+		close(p.shutdownChan)
+	})
 	p.service.Shutdown()
 }
 

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -24,9 +24,10 @@ type Provider struct {
 	status                of.State
 	mtx                   parallel.RWMutex
 
-	shutdownChan chan struct{}
-	shutdownOnce parallel.Once
-	eventStream  chan of.Event
+	shutdownChan    chan struct{}
+	shutdownOnce    parallel.Once
+	handleEventsWg  parallel.WaitGroup
+	eventStream     chan of.Event
 }
 
 func NewProvider(opts ...ProviderOption) (*Provider, error) {
@@ -105,6 +106,10 @@ func (p *Provider) Init(_ of.EvaluationContext) error {
 		return nil
 	}
 
+	// Reset shutdown state so this instance can be re-initialized after a prior Shutdown().
+	p.shutdownChan = make(chan struct{})
+	p.shutdownOnce = parallel.Once{}
+
 	// Create a timer for the initialization deadline that covers the entire init process
 	deadline := time.Duration(p.providerConfiguration.DeadlineMs) * time.Millisecond
 	timer := time.NewTimer(deadline)
@@ -135,6 +140,7 @@ func (p *Provider) Init(_ of.EvaluationContext) error {
 				p.status = of.ReadyState
 				p.initialized = true
 				// start event handling after the first ready event
+				p.handleEventsWg.Add(1)
 				go p.handleEvents()
 				return nil
 			}
@@ -154,6 +160,7 @@ func (p *Provider) Init(_ of.EvaluationContext) error {
 // It exits when the service event channel closes (on Shutdown) or the shutdownChan
 // is closed, ensuring the goroutine is never leaked.
 func (p *Provider) handleEvents() {
+	defer p.handleEventsWg.Done()
 	serviceEventChan := p.service.EventChannel()
 	for {
 		select {
@@ -186,13 +193,16 @@ func (p *Provider) Status() of.State {
 
 func (p *Provider) Shutdown() {
 	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
 	p.initialized = false
 	p.shutdownOnce.Do(func() {
 		close(p.shutdownChan)
 	})
 	p.service.Shutdown()
+	p.mtx.Unlock()
+
+	// Wait outside the lock so handleEvents can finish any in-progress setStatus call
+	// (which also acquires mtx) without deadlocking.
+	p.handleEventsWg.Wait()
 }
 
 func (p *Provider) EventChannel() <-chan of.Event {

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -24,10 +24,10 @@ type Provider struct {
 	status                of.State
 	mtx                   parallel.RWMutex
 
-	shutdownChan    chan struct{}
-	shutdownOnce    parallel.Once
-	handleEventsWg  parallel.WaitGroup
-	eventStream     chan of.Event
+	shutdownChan   chan struct{}
+	shutdownOnce   parallel.Once
+	handleEventsWg parallel.WaitGroup
+	eventStream    chan of.Event
 }
 
 func NewProvider(opts ...ProviderOption) (*Provider, error) {

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -719,3 +719,55 @@ func TestHandleEventsChannelClose(t *testing.T) {
 	// Clean up to avoid affecting other tests
 	provider.Shutdown()
 }
+
+// TestShutdownUnblocksBlockedSend verifies that Shutdown() returns promptly even when
+// handleEvents is blocked trying to send an event to the unbuffered eventStream channel
+// (i.e. no consumer is reading from provider.EventChannel()).
+func TestShutdownUnblocksBlockedSend(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eventChan := make(chan of.Event)
+
+	provider, err := NewProvider()
+	if err != nil {
+		t.Fatal("error creating new provider", err)
+	}
+
+	svcMock := mock.NewMockIService(ctrl)
+	provider.service = svcMock
+	svcMock.EXPECT().Init().DoAndReturn(func() error {
+		go func() {
+			// Send the ready event so Init() completes and handleEvents starts
+			eventChan <- of.Event{ProviderName: "flagd", EventType: of.ProviderReady}
+			// Send a second event that handleEvents will try to forward to the
+			// unbuffered p.eventStream — nobody is reading, so it will block.
+			eventChan <- of.Event{ProviderName: "flagd", EventType: of.ProviderConfigChange}
+		}()
+		return nil
+	}).Times(1)
+	svcMock.EXPECT().EventChannel().Return(eventChan).AnyTimes()
+	svcMock.EXPECT().Shutdown().Times(1)
+
+	if err := provider.Init(of.EvaluationContext{}); err != nil {
+		t.Fatalf("unexpected init error: %v", err)
+	}
+
+	// Give handleEvents time to receive the config-change event and block on the send.
+	time.Sleep(50 * time.Millisecond)
+
+	// Shutdown must complete quickly; if shutdownChan doesn't unblock the send
+	// this will hang and the test timeout will fire.
+	done := make(chan struct{})
+	go func() {
+		provider.Shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown() blocked: handleEvents goroutine was not unblocked by shutdownChan")
+	}
+}

--- a/providers/flagd/pkg/provider_test.go
+++ b/providers/flagd/pkg/provider_test.go
@@ -771,3 +771,67 @@ func TestShutdownUnblocksBlockedSend(t *testing.T) {
 		t.Fatal("Shutdown() blocked: handleEvents goroutine was not unblocked by shutdownChan")
 	}
 }
+
+// TestReinitAfterShutdown verifies that calling Init() on a provider that has already been
+// shut down works correctly. Before the fix, shutdownChan was already closed so the new
+// handleEvents goroutine would exit immediately, silently breaking event forwarding.
+func TestReinitAfterShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	provider, err := NewProvider()
+	if err != nil {
+		t.Fatal("error creating new provider", err)
+	}
+
+	svcMock := mock.NewMockIService(ctrl)
+	provider.service = svcMock
+
+	eventChan := make(chan of.Event)
+	svcMock.EXPECT().EventChannel().Return(eventChan).AnyTimes()
+
+	gomock.InOrder(
+		svcMock.EXPECT().Init().DoAndReturn(func() error {
+			go func() { eventChan <- of.Event{ProviderName: "flagd", EventType: of.ProviderReady} }()
+			return nil
+		}),
+		svcMock.EXPECT().Init().DoAndReturn(func() error {
+			go func() { eventChan <- of.Event{ProviderName: "flagd", EventType: of.ProviderReady} }()
+			return nil
+		}),
+	)
+	svcMock.EXPECT().Shutdown().Times(1)
+
+	// First cycle
+	if err := provider.Init(of.EvaluationContext{}); err != nil {
+		t.Fatalf("first Init() failed: %v", err)
+	}
+	provider.Shutdown()
+
+	// Second Init — must succeed and not hang.
+	done := make(chan error, 1)
+	go func() { done <- provider.Init(of.EvaluationContext{}) }()
+	select {
+	case initErr := <-done:
+		if initErr != nil {
+			t.Fatalf("second Init() returned error: %v", initErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second Init() hung; shutdownChan was not reset after Shutdown()")
+	}
+
+	// Verify handleEvents is alive by confirming a post-init event is forwarded.
+	// Without the fix, shutdownChan is already closed and handleEvents exits immediately,
+	// so this send would block forever and the test would time out.
+	received := make(chan of.Event, 1)
+	go func() { received <- <-provider.EventChannel() }()
+	eventChan <- of.Event{ProviderName: "flagd", EventType: of.ProviderConfigChange}
+	select {
+	case e := <-received:
+		if e.EventType != of.ProviderConfigChange {
+			t.Fatalf("unexpected event type after re-init: %v", e.EventType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("event not forwarded after re-init; handleEvents goroutine exited prematurely")
+	}
+}

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -440,6 +440,7 @@ func (i *InProcess) Shutdown() {
 
 		i.logger.Info("waiting for background processes to complete")
 		i.wg.Wait()
+		close(i.events)
 		i.logger.Info("InProcess service shutdown completed successfully")
 	})
 }

--- a/providers/flagd/pkg/service/rpc/service.go
+++ b/providers/flagd/pkg/service/rpc/service.go
@@ -108,6 +108,7 @@ func (s *Service) Shutdown() {
 		s.cancelHook()
 	}
 	s.wg.Wait()
+	close(s.events)
 }
 
 // ResolveBoolean handles the flag evaluation response from the flagd ResolveBoolean rpc


### PR DESCRIPTION
Services (RPC and in-process) now close their event channels after wg.Wait() completes on Shutdown(). This unblocks the handleEvents range loop so the goroutine exits cleanly.

handleEvents is refactored from a simple range loop to a select-based loop with a shutdownChan signal. This prevents two problems:

1. Blocked-send deadlock: the old range loop could be stuck on an unbuffered p.eventStream <- event send when Shutdown is called. The new inner select races the send against shutdownChan so Shutdown never hangs.

2. Unsafe close of a public channel: p.eventStream is held by the go-sdk's event executor. Closing it from handleEvents would panic on re-initialization and violates the ownership contract. Instead we exit via shutdownChan and leave eventStream open; the go-sdk's shutdownSemaphore mechanism handles its own listener goroutine when the provider is replaced.

shutdownOnce guards the channel close so calling Shutdown more than once is safe.

Closes #845

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

