### PR TITLE
ci: GO vulncheck is failing because of go 1.25.8, bumping to 1.25.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
 
 jobs:
   lint:


### PR DESCRIPTION
## This PR
GO vulncheck is failing because of go 1.25.8, bumping to 1.25.9