### PR TITLE
chore: make govulncheck non-blocking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Run workspace init
         run: make workspace-init
       - name: Run Vulncheck
+        continue-on-error: true
         run: make vulncheck
       - name: Run linter
         run: make lint


### PR DESCRIPTION
## Summary
- Makes govulncheck advisory (non-blocking) in CI via `continue-on-error: true`
- Vulncheck results still visible on PRs but won't block merges
- Libraries shouldn't be blocked by transitive vuln issues with no available fix