### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/tests/flagd/go.mod
+++ b/tests/flagd/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
-	github.com/in-toto/in-toto-golang v0.10.0 // indirect
+	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect

--- a/tests/flagd/go.sum
+++ b/tests/flagd/go.sum
@@ -244,8 +244,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/in-toto/attestation v1.1.2 h1:MBFn6lsMq6dptQZJBhalXTcWMb/aJy3V+GX3VYj/V1E=
 github.com/in-toto/attestation v1.1.2/go.mod h1:gYFddHMZj3DiQ0b62ltNi1Vj5rC879bTmBbrv9CRHpM=
-github.com/in-toto/in-toto-golang v0.10.0 h1:+s2eZQSK3WmWfYV85qXVSBfqgawi/5L02MaqA4o/tpM=
-github.com/in-toto/in-toto-golang v0.10.0/go.mod h1:wjT4RiyFlLWCmLUJjwB8oZcjaq7HA390aMJcD3xXgmg=
+github.com/in-toto/in-toto-golang v0.11.0 h1:nfidMYBFx+E0lnmX5KUnN2Pdm8zdNKal1ayjJuzzRoA=
+github.com/in-toto/in-toto-golang v0.11.0/go.mod h1:u3PjTnwFKjp5a1YCcw8SJg0G+tMeKfVoWsWeFMDCMtw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf h1:FtEj8sfIcaaBfAKrE1Cwb61YDtYq9JxChK1c7AKce7s=


### PR DESCRIPTION
## Summary

- Bumped `github.com/in-toto/in-toto-golang` from v0.10.0 to v0.11.0 in `tests/flagd/go.mod` to resolve a medium-severity vulnerability (alert #112, [GHSA-pmwq-pjrm-6p5r](https://github.com/advisories/GHSA-pmwq-pjrm-6p5r)).
- The matching alert on `providers/flagd/e2e/go.mod` (#111) was already resolved by #865.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #112 | `github.com/in-toto/in-toto-golang` | **medium** | Bumped to v0.11.0 in `tests/flagd/go.mod` |

## Unresolvable Alerts

| Alert | Package | Severity | Reason |
|-------|---------|----------|--------|
| #99, #98 | `github.com/docker/docker` | **high** | No patched version available for Go ecosystem (Moby AuthZ plugin bypass) |
| #97, #96 | `github.com/docker/docker` | **medium** | No patched version available for Go ecosystem (off-by-one in plugin privilege validation) |
| #114, #113 | `github.com/docker/docker` | **high** | No patched version available for Go ecosystem (`PUT /containers/{id}/archive` executes container binary) |
| #118, #117 | `github.com/docker/docker` | **high** | No patched version available for Go ecosystem (`docker cp` bind mount redirection) |
| #116, #115 | `github.com/docker/docker` | **medium** | No patched version available for Go ecosystem (`docker cp` symlink swap) |

The `github.com/docker/docker` alerts apply only to the e2e test modules and have no patched version published for the Go ecosystem; they will auto-resolve when upstream releases a fix.