### PR TITLE
feat: make use of flagd-selector header in RPC mode

### DIFF
--- a/providers/flagd/internal/flagdmeta/header.go
+++ b/providers/flagd/internal/flagdmeta/header.go
@@ -1,5 +1,5 @@
-// Package header defines metadata header keys shared by the flagd resolvers.
-package header
+// Package flagdmeta defines metadata header keys shared by the flagd resolvers.
+package flagdmeta
 
 // Selector is the metadata header used to pass the flag-set selector to flagd.
 const Selector = "flagd-selector"

--- a/providers/flagd/internal/header/header.go
+++ b/providers/flagd/internal/header/header.go
@@ -1,0 +1,5 @@
+// Package header defines metadata header keys shared by the flagd resolvers.
+package header
+
+// Selector is the metadata header used to pass the flag-set selector to flagd.
+const Selector = "flagd-selector"

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -58,6 +58,7 @@ func NewProvider(opts ...ProviderOption) (*Provider, error) {
 				TLSEnabled:      provider.providerConfiguration.Tls,
 				OtelInterceptor: provider.providerConfiguration.OtelIntercept,
 				DeadlineMs:      provider.providerConfiguration.DeadlineMs,
+				Selector:        provider.providerConfiguration.Selector,
 			},
 			cacheService,
 			provider.providerConfiguration.log,

--- a/providers/flagd/pkg/service/in_process/grpc_interceptors.go
+++ b/providers/flagd/pkg/service/in_process/grpc_interceptors.go
@@ -3,7 +3,7 @@ package process
 import (
 	"context"
 
-	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/flagdmeta"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -19,7 +19,7 @@ func selectorUnaryInterceptor(selector string) grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		if selector != "" {
-			ctx = metadata.AppendToOutgoingContext(ctx, header.Selector, selector)
+			ctx = metadata.AppendToOutgoingContext(ctx, flagdmeta.Selector, selector)
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
@@ -36,7 +36,7 @@ func selectorStreamInterceptor(selector string) grpc.StreamClientInterceptor {
 		opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
 		if selector != "" {
-			ctx = metadata.AppendToOutgoingContext(ctx, header.Selector, selector)
+			ctx = metadata.AppendToOutgoingContext(ctx, flagdmeta.Selector, selector)
 		}
 		return streamer(ctx, desc, cc, method, opts...)
 	}

--- a/providers/flagd/pkg/service/in_process/grpc_interceptors.go
+++ b/providers/flagd/pkg/service/in_process/grpc_interceptors.go
@@ -3,11 +3,10 @@ package process
 import (
 	"context"
 
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
-
-const SelectorMetadataKey = "flagd-selector"
 
 // selectorUnaryInterceptor adds the flagd-selector metadata header to unary gRPC calls
 func selectorUnaryInterceptor(selector string) grpc.UnaryClientInterceptor {
@@ -20,7 +19,7 @@ func selectorUnaryInterceptor(selector string) grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		if selector != "" {
-			ctx = metadata.AppendToOutgoingContext(ctx, SelectorMetadataKey, selector)
+			ctx = metadata.AppendToOutgoingContext(ctx, header.Selector, selector)
 		}
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
@@ -37,7 +36,7 @@ func selectorStreamInterceptor(selector string) grpc.StreamClientInterceptor {
 		opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
 		if selector != "" {
-			ctx = metadata.AppendToOutgoingContext(ctx, SelectorMetadataKey, selector)
+			ctx = metadata.AppendToOutgoingContext(ctx, header.Selector, selector)
 		}
 		return streamer(ctx, desc, cc, method, opts...)
 	}

--- a/providers/flagd/pkg/service/in_process/service_selector_header_test.go
+++ b/providers/flagd/pkg/service/in_process/service_selector_header_test.go
@@ -10,6 +10,7 @@ import (
 
 	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
 	v1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -180,7 +181,7 @@ func (s *selectorHeaderCapturingServer) GetMetadata(ctx context.Context, req *v1
 func (s *selectorHeaderCapturingServer) captureHeader(ctx context.Context) {
 	md, _ := metadata.FromIncomingContext(ctx)
 	headerValue := ""
-if values := md.Get(SelectorMetadataKey); len(values) > 0 {
+if values := md.Get(header.Selector); len(values) > 0 {
 		headerValue = values[0]
 	}
 	select {

--- a/providers/flagd/pkg/service/in_process/service_selector_header_test.go
+++ b/providers/flagd/pkg/service/in_process/service_selector_header_test.go
@@ -10,7 +10,7 @@ import (
 
 	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
 	v1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
-	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/flagdmeta"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -181,7 +181,7 @@ func (s *selectorHeaderCapturingServer) GetMetadata(ctx context.Context, req *v1
 func (s *selectorHeaderCapturingServer) captureHeader(ctx context.Context) {
 	md, _ := metadata.FromIncomingContext(ctx)
 	headerValue := ""
-if values := md.Get(header.Selector); len(values) > 0 {
+if values := md.Get(flagdmeta.Selector); len(values) > 0 {
 		headerValue = values[0]
 	}
 	select {

--- a/providers/flagd/pkg/service/rpc/interceptors.go
+++ b/providers/flagd/pkg/service/rpc/interceptors.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/flagdmeta"
 )
 
 // selectorInterceptor is a connect.Interceptor that adds the flagd-selector header.
@@ -19,7 +19,7 @@ func newSelectorInterceptor(selector string) *selectorInterceptor {
 func (i *selectorInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		if i.selector != "" {
-			req.Header().Set(header.Selector, i.selector)
+			req.Header().Set(flagdmeta.Selector, i.selector)
 		}
 		return next(ctx, req)
 	}
@@ -29,7 +29,7 @@ func (i *selectorInterceptor) WrapStreamingClient(next connect.StreamingClientFu
 	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
 		conn := next(ctx, spec)
 		if i.selector != "" {
-			conn.RequestHeader().Set(header.Selector, i.selector)
+			conn.RequestHeader().Set(flagdmeta.Selector, i.selector)
 		}
 		return conn
 	}

--- a/providers/flagd/pkg/service/rpc/interceptors.go
+++ b/providers/flagd/pkg/service/rpc/interceptors.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
+)
+
+// selectorInterceptor is a connect.Interceptor that adds the flagd-selector header.
+type selectorInterceptor struct {
+	selector string
+}
+
+func newSelectorInterceptor(selector string) *selectorInterceptor {
+	return &selectorInterceptor{selector: selector}
+}
+
+func (i *selectorInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if i.selector != "" {
+			req.Header().Set(header.Selector, i.selector)
+		}
+		return next(ctx, req)
+	}
+}
+
+func (i *selectorInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		if i.selector != "" {
+			conn.RequestHeader().Set(header.Selector, i.selector)
+		}
+		return conn
+	}
+}
+
+func (i *selectorInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	// server-side; not used by the client
+	return next
+}

--- a/providers/flagd/pkg/service/rpc/interceptors_test.go
+++ b/providers/flagd/pkg/service/rpc/interceptors_test.go
@@ -1,0 +1,103 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	schemaConnectV2 "buf.build/gen/go/open-feature/flagd/connectrpc/go/flagd/evaluation/v2/evaluationv2connect"
+	schemaV2 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/evaluation/v2"
+	"connectrpc.com/connect"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
+)
+
+// TestSelectorInterceptor_Unary verifies the flagd-selector header is added
+// to outgoing unary requests when a selector is configured, and omitted when
+// it is not.
+func TestSelectorInterceptor_Unary(t *testing.T) {
+	tests := []struct {
+		name          string
+		selector      string
+		expectedValue string
+	}{
+		{"sends header when configured", "source=db,app=myapp", "source=db,app=myapp"},
+		{"omits header when empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interceptor := newSelectorInterceptor(tt.selector)
+			req := connect.NewRequest(&schemaV2.ResolveBooleanRequest{FlagKey: "k"})
+
+			wrapped := interceptor.WrapUnary(func(_ context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				got := req.Header().Get(header.Selector)
+				if got != tt.expectedValue {
+					t.Errorf("expected header %q, got %q", tt.expectedValue, got)
+				}
+				return connect.NewResponse(&schemaV2.ResolveBooleanResponse{}), nil
+			})
+
+			if _, err := wrapped(context.Background(), req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestSelectorInterceptor_E2E spins up a real connect server and verifies the
+// flagd-selector header arrives on the server side via a unary call.
+func TestSelectorInterceptor_E2E(t *testing.T) {
+	tests := []struct {
+		name         string
+		selector     string
+		expectHeader bool
+	}{
+		{"with selector", "source=db", true},
+		{"without selector", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			received := make(chan string, 1)
+			mux := http.NewServeMux()
+			path, handler := schemaConnectV2.NewServiceHandler(&headerCapturingHandler{received: received})
+			mux.Handle(path, handler)
+
+			srv := httptest.NewUnstartedServer(mux)
+			srv.EnableHTTP2 = true
+			srv.StartTLS()
+			defer srv.Close()
+
+			httpClient := srv.Client()
+			var opts []connect.ClientOption
+			if tt.selector != "" {
+				opts = append(opts, connect.WithInterceptors(newSelectorInterceptor(tt.selector)))
+			}
+			client := schemaConnectV2.NewServiceClient(httpClient, srv.URL, opts...)
+
+			_, err := client.ResolveBoolean(context.Background(), connect.NewRequest(&schemaV2.ResolveBooleanRequest{FlagKey: "k"}))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := <-received
+			if tt.expectHeader && got != tt.selector {
+				t.Errorf("expected header %q, got %q", tt.selector, got)
+			}
+			if !tt.expectHeader && got != "" {
+				t.Errorf("expected no header, got %q", got)
+			}
+		})
+	}
+}
+
+type headerCapturingHandler struct {
+	schemaConnectV2.UnimplementedServiceHandler
+	received chan string
+}
+
+func (h *headerCapturingHandler) ResolveBoolean(_ context.Context, req *connect.Request[schemaV2.ResolveBooleanRequest]) (*connect.Response[schemaV2.ResolveBooleanResponse], error) {
+	h.received <- req.Header().Get(header.Selector)
+	return connect.NewResponse(&schemaV2.ResolveBooleanResponse{}), nil
+}

--- a/providers/flagd/pkg/service/rpc/interceptors_test.go
+++ b/providers/flagd/pkg/service/rpc/interceptors_test.go
@@ -9,7 +9,7 @@ import (
 	schemaConnectV2 "buf.build/gen/go/open-feature/flagd/connectrpc/go/flagd/evaluation/v2/evaluationv2connect"
 	schemaV2 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/evaluation/v2"
 	"connectrpc.com/connect"
-	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/header"
+	"github.com/open-feature/go-sdk-contrib/providers/flagd/internal/flagdmeta"
 )
 
 // TestSelectorInterceptor_Unary verifies the flagd-selector header is added
@@ -31,7 +31,7 @@ func TestSelectorInterceptor_Unary(t *testing.T) {
 			req := connect.NewRequest(&schemaV2.ResolveBooleanRequest{FlagKey: "k"})
 
 			wrapped := interceptor.WrapUnary(func(_ context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-				got := req.Header().Get(header.Selector)
+				got := req.Header().Get(flagdmeta.Selector)
 				if got != tt.expectedValue {
 					t.Errorf("expected header %q, got %q", tt.expectedValue, got)
 				}
@@ -98,6 +98,6 @@ type headerCapturingHandler struct {
 }
 
 func (h *headerCapturingHandler) ResolveBoolean(_ context.Context, req *connect.Request[schemaV2.ResolveBooleanRequest]) (*connect.Response[schemaV2.ResolveBooleanResponse], error) {
-	h.received <- req.Header().Get(header.Selector)
+	h.received <- req.Header().Get(flagdmeta.Selector)
 	return connect.NewResponse(&schemaV2.ResolveBooleanResponse{}), nil
 }

--- a/providers/flagd/pkg/service/rpc/service.go
+++ b/providers/flagd/pkg/service/rpc/service.go
@@ -40,6 +40,7 @@ type Configuration struct {
 	TLSEnabled      bool
 	OtelInterceptor bool
 	DeadlineMs      int
+	Selector        string
 }
 
 // Service handles the client side  interface for the flagd server
@@ -698,6 +699,10 @@ func newClient(cfg Configuration) (schemaConnectV2.ServiceClient, error) {
 		}
 
 		options = append(options, connect.WithInterceptors(interceptor))
+	}
+
+	if cfg.Selector != "" {
+		options = append(options, connect.WithInterceptors(newSelectorInterceptor(cfg.Selector)))
 	}
 
 	return schemaConnectV2.NewServiceClient(


### PR DESCRIPTION
- The in-process resolver already sends the `flagd-selector` gRPC metadata header, but the RPC resolver did not. This PR wires it up: the RPC resolver now sends the header on every call when a selector is configured, so the flagd server can serve the requested flag set.
- Brings the Go RPC resolver to parity with the Java, JS, .NET, and Python providers, which all already wire this header up (see flagd issue [#1814](https://github.com/open-feature/flagd/issues/1814)).
- Additive: behavior is unchanged when no selector is configured.

We missed the RPC mode in: #789
