### PR TITLE
fix(flagd): resolve data race in InProcess service

### DIFF
--- a/providers/flagd/pkg/service/in_process/grpc_sync.go
+++ b/providers/flagd/pkg/service/in_process/grpc_sync.go
@@ -207,7 +207,7 @@ func (g *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 					}
 				}
 			}
-			g.sendEvent(ctx, SyncEvent{event: of.ProviderError})
+			g.sendEvent(ctx, SyncEvent{Event: of.ProviderError})
 
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -362,7 +362,7 @@ func (g *Sync) handleConnectionState(ctx context.Context, state connectivity.Sta
 	switch state {
 	case connectivity.TransientFailure:
 		g.Logger.Error(fmt.Sprintf("gRPC connection entered TransientFailure state for %s", g.URI))
-		g.sendEvent(ctx, SyncEvent{event: of.ProviderError})
+		g.sendEvent(ctx, SyncEvent{Event: of.ProviderError})
 
 	case connectivity.Shutdown:
 		g.Logger.Error(fmt.Sprintf("gRPC connection shutdown for %s", g.URI))

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -56,7 +56,8 @@ type InProcess struct {
 
 	// Stateless coordination using sync.Once
 	initOnce            sync.Once
-	sendReadyOnNextData *sync.Once
+	readyMu             sync.Mutex
+	ready               bool
 	staleTimer          *staleTimer
 }
 
@@ -152,7 +153,6 @@ func NewInProcessService(cfg Configuration) *InProcess {
 		configuration:       cfg,
 		serviceMetadata:     createServiceMetadata(cfg),
 		events:              make(chan of.Event, eventChannelBuffer),
-		sendReadyOnNextData: &sync.Once{},
 		staleTimer:          newStaleTimer(),
 		deadlineMs:          cfg.DeadlineMs,
 	}
@@ -235,7 +235,9 @@ func (i *InProcess) handleSyncEvent(event SyncEvent) {
 	switch event.Event {
 	case of.ProviderError:
 		i.handleProviderError()
-		i.sendReadyOnNextData = &sync.Once{}
+		i.readyMu.Lock()
+		i.ready = false
+		i.readyMu.Unlock()
 	case of.ProviderReady:
 		i.handleProviderReady()
 	}
@@ -344,9 +346,17 @@ func (i *InProcess) processSyncData(data isync.DataSync) {
 	i.staleTimer.stop()
 
 	// Send ready event if not already sent - handles initial ready and recovery automatically
-	i.sendReadyOnNextData.Do(func() {
+	var sendReady bool
+	i.readyMu.Lock()
+	if !i.ready {
+		i.ready = true
+		sendReady = true
+	}
+	i.readyMu.Unlock()
+
+	if sendReady {
 		i.events <- of.Event{ProviderName: providerName, EventType: of.ProviderReady}
-	})
+	}
 
 	// Handle initialization completion (only happens once ever)
 	i.initOnce.Do(func() {

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -234,10 +234,10 @@ func (i *InProcess) runEventSyncMonitor() {
 func (i *InProcess) handleSyncEvent(event SyncEvent) {
 	switch event.Event {
 	case of.ProviderError:
-		i.handleProviderError()
 		i.readyMu.Lock()
 		i.ready = false
 		i.readyMu.Unlock()
+		i.handleProviderError()
 	case of.ProviderReady:
 		i.handleProviderReady()
 	}
@@ -334,6 +334,9 @@ func (i *InProcess) processSyncData(data isync.DataSync) {
 
 	err = i.evaluator.SetState(data)
 	if err != nil {
+		i.readyMu.Lock()
+		i.ready = false
+		i.readyMu.Unlock()
 		i.events <- of.Event{
 			ProviderName:         providerName,
 			EventType:            of.ProviderError,

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -56,7 +56,7 @@ type InProcess struct {
 
 	// Stateless coordination using sync.Once
 	initOnce            sync.Once
-	sendReadyOnNextData sync.Once
+	sendReadyOnNextData *sync.Once
 	staleTimer          *staleTimer
 }
 
@@ -128,7 +128,7 @@ type EventSync interface {
 
 // SyncEvent represents an event from the sync provider
 type SyncEvent struct {
-	event of.EventType
+	Event of.EventType
 }
 
 // Shutdowner interface for graceful shutdown
@@ -152,8 +152,8 @@ func NewInProcessService(cfg Configuration) *InProcess {
 		configuration:       cfg,
 		serviceMetadata:     createServiceMetadata(cfg),
 		events:              make(chan of.Event, eventChannelBuffer),
+		sendReadyOnNextData: &sync.Once{},
 		staleTimer:          newStaleTimer(),
-		sendReadyOnNextData: sync.Once{}, // Armed and ready to fire on first data
 		deadlineMs:          cfg.DeadlineMs,
 	}
 }
@@ -232,11 +232,10 @@ func (i *InProcess) runEventSyncMonitor() {
 
 // handleSyncEvent processes individual sync events
 func (i *InProcess) handleSyncEvent(event SyncEvent) {
-	switch event.event {
+	switch event.Event {
 	case of.ProviderError:
 		i.handleProviderError()
-		// Reset the sync.Once so it can fire again on recovery
-		i.sendReadyOnNextData = sync.Once{}
+		i.sendReadyOnNextData = &sync.Once{}
 	case of.ProviderReady:
 		i.handleProviderReady()
 	}
@@ -344,7 +343,7 @@ func (i *InProcess) processSyncData(data isync.DataSync) {
 	// Stop stale timer - we've successfully received and processed data
 	i.staleTimer.stop()
 
-	// Send ready event using sync.Once - handles initial ready and recovery automatically
+	// Send ready event if not already sent - handles initial ready and recovery automatically
 	i.sendReadyOnNextData.Do(func() {
 		i.events <- of.Event{ProviderName: providerName, EventType: of.ProviderReady}
 	})

--- a/providers/flagd/pkg/service/in_process/service_test.go
+++ b/providers/flagd/pkg/service/in_process/service_test.go
@@ -1,0 +1,85 @@
+package process_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	isync "github.com/open-feature/flagd/core/pkg/sync"
+	of "github.com/open-feature/go-sdk/openfeature"
+	process "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/in_process"
+)
+
+type mockSync struct {
+	events   chan process.SyncEvent
+	dataChan chan chan<- isync.DataSync
+}
+
+func (m *mockSync) Init(ctx context.Context) error { return nil }
+func (m *mockSync) IsReady() bool                  { return true }
+func (m *mockSync) ReSync(ctx context.Context, data chan<- isync.DataSync) error { return nil }
+func (m *mockSync) Sync(ctx context.Context, data chan<- isync.DataSync) error {
+	m.dataChan <- data
+	<-ctx.Done()
+	return nil
+}
+func (m *mockSync) Events() chan process.SyncEvent {
+	return m.events
+}
+
+func TestInProcessServiceDataRace(t *testing.T) {
+	m := &mockSync{
+		events:   make(chan process.SyncEvent, 100),
+		dataChan: make(chan chan<- isync.DataSync, 1),
+	}
+	service := process.NewInProcessService(process.Configuration{
+		CustomSyncProvider:    m,
+		CustomSyncProviderUri: "test-source",
+	})
+
+	// Start Init in a goroutine because it blocks until first DataSync
+	go service.Init()
+	defer service.Shutdown()
+
+	// Wait for data channel to be passed to Sync
+	var dataChan chan<- isync.DataSync
+	select {
+	case dataChan = <-m.dataChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Sync to be called")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-service.EventChannel():
+			case <-done:
+				return
+			}
+		}
+	}()
+	defer close(done)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			m.events <- process.SyncEvent{Event: of.ProviderError}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			dataChan <- isync.DataSync{FlagData: "{\"flags\":{}}", Source: "test-source"}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/providers/flagd/pkg/service/in_process/service_test.go
+++ b/providers/flagd/pkg/service/in_process/service_test.go
@@ -72,7 +72,7 @@ func TestInProcessServiceDataRace(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			m.events <- process.SyncEvent{Event: of.ProviderError}
 			time.Sleep(time.Millisecond)
 		}
@@ -80,7 +80,7 @@ func TestInProcessServiceDataRace(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			dataChan <- isync.DataSync{FlagData: "{\"flags\":{}}", Source: "test-source"}
 			time.Sleep(time.Millisecond)
 		}

--- a/providers/flagd/pkg/service/in_process/service_test.go
+++ b/providers/flagd/pkg/service/in_process/service_test.go
@@ -28,7 +28,7 @@ func (m *mockSync) Events() chan process.SyncEvent {
 	return m.events
 }
 
-func TestInProcessServiceDataRace(t *testing.T) {
+func TestInProcessServiceDataRace(t *testing.T) { 
 	m := &mockSync{
 		events:   make(chan process.SyncEvent, 100),
 		dataChan: make(chan chan<- isync.DataSync, 1),
@@ -38,14 +38,19 @@ func TestInProcessServiceDataRace(t *testing.T) {
 		CustomSyncProviderUri: "test-source",
 	})
 
+	errChan := make(chan error, 1)
 	// Start Init in a goroutine because it blocks until first DataSync
-	go service.Init()
+	go func() {
+		errChan <- service.Init()
+	}()
 	defer service.Shutdown()
 
 	// Wait for data channel to be passed to Sync
 	var dataChan chan<- isync.DataSync
 	select {
 	case dataChan = <-m.dataChan:
+	case err := <-errChan:
+		t.Fatalf("Init failed: %v", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for Sync to be called")
 	}
@@ -81,5 +86,14 @@ func TestInProcessServiceDataRace(t *testing.T) {
 		}
 	}()
 
-	wg.Wait()
+	c := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(c)
+	}()
+	select {
+	case <-c:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for test to complete")
+	}
 }


### PR DESCRIPTION
This PR fixes a data race in the `InProcess` service of the `flagd` provider. The data race occurred during concurrent handling of provider error events and data synchronization updates.

## Root Cause
The `InProcess` service previously relied on `sync.Once` to manage state transitions (likely for signaling readiness). To allow signaling readiness multiple times (e.g., after a reconnection), the `sync.Once` instance was unsafely re-assigned (reset). This re-assignment is not thread-safe and caused data races when accessed concurrently by the event monitor and data sync process.

## Solution
1. **Replaced `sync.Once` with Mutex and Bool**: Replaced the state-tracking `sync.Once` with a `sync.Mutex` (`readyMu`) and a boolean flag (`ready`) in the `InProcess` struct.
2. **Safe Channel Sends**: Updated `processSyncData` and event handlers to modify the `ready` flag under the lock, but perform the channel sends (`i.events <- ...`) *outside* the lock to avoid potential deadlocks.
3. **Added Regression Test**: Added `TestInProcessServiceDataRace` in `service_test.go` which spawns concurrent goroutines sending error events and data updates to trigger the data race and verify the fix.
