### PR TITLE
chore: use blackbox testing to avoid export

### DIFF
--- a/providers/flagd/pkg/service/in_process/grpc_sync.go
+++ b/providers/flagd/pkg/service/in_process/grpc_sync.go
@@ -207,7 +207,7 @@ func (g *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 					}
 				}
 			}
-			g.sendEvent(ctx, SyncEvent{Event: of.ProviderError})
+			g.sendEvent(ctx, SyncEvent{event: of.ProviderError})
 
 			if ctx.Err() != nil {
 				return ctx.Err()
@@ -362,7 +362,7 @@ func (g *Sync) handleConnectionState(ctx context.Context, state connectivity.Sta
 	switch state {
 	case connectivity.TransientFailure:
 		g.Logger.Error(fmt.Sprintf("gRPC connection entered TransientFailure state for %s", g.URI))
-		g.sendEvent(ctx, SyncEvent{Event: of.ProviderError})
+		g.sendEvent(ctx, SyncEvent{event: of.ProviderError})
 
 	case connectivity.Shutdown:
 		g.Logger.Error(fmt.Sprintf("gRPC connection shutdown for %s", g.URI))

--- a/providers/flagd/pkg/service/in_process/service.go
+++ b/providers/flagd/pkg/service/in_process/service.go
@@ -129,7 +129,7 @@ type EventSync interface {
 
 // SyncEvent represents an event from the sync provider
 type SyncEvent struct {
-	Event of.EventType
+	event of.EventType
 }
 
 // Shutdowner interface for graceful shutdown
@@ -232,7 +232,7 @@ func (i *InProcess) runEventSyncMonitor() {
 
 // handleSyncEvent processes individual sync events
 func (i *InProcess) handleSyncEvent(event SyncEvent) {
-	switch event.Event {
+	switch event.event {
 	case of.ProviderError:
 		i.readyMu.Lock()
 		i.ready = false

--- a/providers/flagd/pkg/service/in_process/service_test.go
+++ b/providers/flagd/pkg/service/in_process/service_test.go
@@ -1,4 +1,4 @@
-package process_test
+package process
 
 import (
 	"context"
@@ -8,32 +8,31 @@ import (
 
 	isync "github.com/open-feature/flagd/core/pkg/sync"
 	of "github.com/open-feature/go-sdk/openfeature"
-	process "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg/service/in_process"
 )
 
 type mockSync struct {
-	events   chan process.SyncEvent
+	events   chan SyncEvent
 	dataChan chan chan<- isync.DataSync
 }
 
-func (m *mockSync) Init(ctx context.Context) error { return nil }
-func (m *mockSync) IsReady() bool                  { return true }
+func (m *mockSync) Init(ctx context.Context) error                               { return nil }
+func (m *mockSync) IsReady() bool                                                { return true }
 func (m *mockSync) ReSync(ctx context.Context, data chan<- isync.DataSync) error { return nil }
 func (m *mockSync) Sync(ctx context.Context, data chan<- isync.DataSync) error {
 	m.dataChan <- data
 	<-ctx.Done()
 	return nil
 }
-func (m *mockSync) Events() chan process.SyncEvent {
+func (m *mockSync) Events() chan SyncEvent {
 	return m.events
 }
 
-func TestInProcessServiceDataRace(t *testing.T) { 
+func TestInProcessServiceDataRace(t *testing.T) {
 	m := &mockSync{
-		events:   make(chan process.SyncEvent, 100),
+		events:   make(chan SyncEvent, 100),
 		dataChan: make(chan chan<- isync.DataSync, 1),
 	}
-	service := process.NewInProcessService(process.Configuration{
+	service := NewInProcessService(Configuration{
 		CustomSyncProvider:    m,
 		CustomSyncProviderUri: "test-source",
 	})
@@ -73,7 +72,7 @@ func TestInProcessServiceDataRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range 100 {
-			m.events <- process.SyncEvent{Event: of.ProviderError}
+			m.events <- SyncEvent{event: of.ProviderError}
 			time.Sleep(time.Millisecond)
 		}
 	}()


### PR DESCRIPTION
Converted `service_test.go` to black box suite to avoid export.