### PR TITLE
fix(go-feature-flag): Typo in the readme file

### DIFF
--- a/providers/go-feature-flag/README.md
+++ b/providers/go-feature-flag/README.md
@@ -221,7 +221,7 @@ Tracking events are queued in the same data collector buffer as flag evaluation 
 
 ### Disabling and tuning event collection
 
-Use the `DataCollector*` options to tune or disable collection:
+Use the `DataCollector` options to tune or disable collection:
 
 | Option | Default | Description |
 | --- | --- | --- |


### PR DESCRIPTION
Typo in the readme file