### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/tests/flagd/go.mod
+++ b/tests/flagd/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/sigstore/sigstore v1.10.8 // indirect
-	github.com/sigstore/sigstore-go v1.2.0 // indirect
+	github.com/sigstore/sigstore-go v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect

--- a/tests/flagd/go.sum
+++ b/tests/flagd/go.sum
@@ -376,8 +376,8 @@ github.com/sigstore/rekor-tiles/v2 v2.2.2-0.20260601073857-5d098a2b6443 h1:/CO8F
 github.com/sigstore/rekor-tiles/v2 v2.2.2-0.20260601073857-5d098a2b6443/go.mod h1:w1h8wF8vq9lHjmtRdwJiEaoVxhP+WHIMpj4M39pkzp0=
 github.com/sigstore/sigstore v1.10.8 h1:1Mgkxvkw4AXMfIP1DOjc6kw0GkUgA8pGVpveN/EfOq4=
 github.com/sigstore/sigstore v1.10.8/go.mod h1:f9+B/4iaYimvUkySyb2mvc73n3RLqNn24grHZM/ET8M=
-github.com/sigstore/sigstore-go v1.2.0 h1:8k8sGMVUUWwZ/KA+s4Q66yEPEzcC1xZ8UsTgI46J9Fc=
-github.com/sigstore/sigstore-go v1.2.0/go.mod h1:I8BqVwAb/SaQJ5pBu5IDFY+ksq8O/1/kCag8XUgrsko=
+github.com/sigstore/sigstore-go v1.2.1 h1:YWP/rDbBaEBvtbkj6xtwsSj38ZCFEhTVVadNOXjVe3A=
+github.com/sigstore/sigstore-go v1.2.1/go.mod h1:I8BqVwAb/SaQJ5pBu5IDFY+ksq8O/1/kCag8XUgrsko=
 github.com/sigstore/timestamp-authority/v2 v2.1.2 h1:7DDhnknLL4w8VwomyvW2W8qblOS9LDR8oihna+jc7Ls=
 github.com/sigstore/timestamp-authority/v2 v2.1.2/go.mod h1:o6rAVZceFyejClIj/uStRNIemP16bVMZtbMmhk6pr0U=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=


### PR DESCRIPTION
## Summary

- Resolved 2 of 12 open Dependabot security alerts by bumping `github.com/sigstore/sigstore-go` to the patched release in both affected Go modules
- The remaining 10 alerts (all `github.com/docker/docker`, used only as an indirect/transitive test dependency in `tests/flagd` and `providers/flagd/e2e`) could not be resolved at this time — see notes below

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #162 | `github.com/sigstore/sigstore-go` | **low** | Bumped to v1.2.1 in `tests/flagd/go.mod` |
| #161 | `github.com/sigstore/sigstore-go` | **low** | Bumped to v1.2.1 in `providers/flagd/e2e/go.mod` |

## Alerts Not Resolved (unresolvable at this time)

| Alert | Package | Severity | Reason |
|-------|---------|----------|--------|
| #118 / #117 | `github.com/docker/docker` | high | Advisory patched version is `null` for the matched vulnerable range (`<= 28.5.2`) |
| #116 / #115 | `github.com/docker/docker` | medium | Advisory patched version is `null` for the matched vulnerable range (`<= 28.5.2`) |
| #114 / #113 | `github.com/docker/docker` | high | Advisory patched version is `null` for the matched vulnerable range (`<= 28.5.2`) |
| #99 / #98 | `github.com/docker/docker` | high | Advisory lists patched version `29.3.1`, but no `v29.x` tag exists yet in the Go module proxy or upstream `moby/moby` releases (latest published tag is `v28.5.2`) — cannot pin to a version that does not exist |
| #97 / #96 | `github.com/docker/docker` | medium | Advisory patched version is `null` for the matched vulnerable range (`< 29.3.1`) |

`github.com/docker/docker` is only pulled in as an indirect dependency (via `testcontainers-go`) used for spinning up containers in e2e/integration tests, not shipped in any production binary.

## Test plan

- [x] `tests/flagd`: `go build ./...` passes
- [x] `tests/flagd`: `go vet ./...` and `go test ./...` fail with a pre-existing, unrelated build error in a pinned dependency (`providers/flagd@v0.3.0`) — confirmed present on `main` prior to this change as well
- [x] `providers/flagd/e2e`: `go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run ./...` all pass
