### PR TITLE
fix(launchdarkly): pass slog-style attributes to Logger

### DIFF
--- a/providers/launchdarkly/pkg/provider.go
+++ b/providers/launchdarkly/pkg/provider.go
@@ -105,7 +105,7 @@ func (p *Provider) toMultiLDContext(evalCtx openfeature.FlattenedContext) (ldcon
 			continue
 		}
 
-		p.l.Debug("mapping %q context kind", key)
+		p.l.Debug(fmt.Sprintf("mapping %q context kind", key))
 		if innerCtx, ok := attrs.(map[string]any); ok {
 			ctx, err := p.mapContext(ldcontext.Kind(key), openfeature.FlattenedContext(innerCtx))
 			if err != nil {
@@ -113,7 +113,7 @@ func (p *Provider) toMultiLDContext(evalCtx openfeature.FlattenedContext) (ldcon
 			}
 			ldCtx.Add(ctx)
 		} else {
-			p.l.Warn("multi-context: unexpected type in top-level attribute: %s", key)
+			p.l.Warn(fmt.Sprintf("multi-context: unexpected type in top-level attribute: %s", key))
 		}
 	}
 
@@ -173,7 +173,7 @@ func (p *Provider) toLDContext(evalCtx openfeature.FlattenedContext) (ldcontext.
 	if ok && strings.Trim(k, " ") != "" {
 		kind = ldcontext.Kind(k)
 	} else {
-		p.l.Warn("no context kind set, setting %q by default", kind)
+		p.l.Warn(fmt.Sprintf("no context kind set, setting %q by default", kind))
 	}
 
 	if kind == ldcontext.MultiKind {
@@ -224,7 +224,7 @@ func (p *Provider) toResolutionError(errorKind ldreason.EvalErrorKind, reason st
 // toProviderResolutionDetail maps LaunchDarkly's flag resolution details to
 // OPen
 func (p *Provider) toProviderResolutionDetail(detail ldreason.EvaluationDetail) openfeature.ProviderResolutionDetail {
-	p.l.Debug("launchdarkly evaluation detail: %v", detail)
+	p.l.Debug(fmt.Sprintf("launchdarkly evaluation detail: %v", detail))
 
 	ofDetail := openfeature.ProviderResolutionDetail{
 		Reason: p.toReason(detail.Reason.GetKind()),
@@ -288,7 +288,7 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flagKey string, defaul
 
 	value, detail, err := p.client.BoolVariationDetail(flagKey, ldCtx, defaultValue)
 	if err != nil {
-		p.l.Error("boolean evaluation: %s", err)
+		p.l.Error(fmt.Sprintf("boolean evaluation: %s", err))
 	}
 
 	return openfeature.BoolResolutionDetail{
@@ -309,7 +309,7 @@ func (p *Provider) StringEvaluation(ctx context.Context, flagKey string, default
 
 	value, detail, err := p.client.StringVariationDetail(flagKey, ldCtx, defaultValue)
 	if err != nil {
-		p.l.Error("string evaluation: %s", err)
+		p.l.Error(fmt.Sprintf("string evaluation: %s", err))
 	}
 
 	return openfeature.StringResolutionDetail{
@@ -330,7 +330,7 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flagKey string, defaultV
 
 	value, detail, err := p.client.Float64VariationDetail(flagKey, ldCtx, defaultValue)
 	if err != nil {
-		p.l.Error("float evaluation: %s", err)
+		p.l.Error(fmt.Sprintf("float evaluation: %s", err))
 	}
 
 	return openfeature.FloatResolutionDetail{
@@ -351,7 +351,7 @@ func (p *Provider) IntEvaluation(ctx context.Context, flagKey string, defaultVal
 
 	value, detail, err := p.client.IntVariationDetail(flagKey, ldCtx, int(defaultValue))
 	if err != nil {
-		p.l.Error("int evaluation: %s", err)
+		p.l.Error(fmt.Sprintf("int evaluation: %s", err))
 	}
 
 	return openfeature.IntResolutionDetail{
@@ -372,7 +372,7 @@ func (p *Provider) ObjectEvaluation(ctx context.Context, flagKey string, default
 
 	value, detail, err := p.client.JSONVariationDetail(flagKey, ldCtx, ldvalue.CopyArbitraryValue(defaultValue))
 	if err != nil {
-		p.l.Error("object evaluation: %s", err)
+		p.l.Error(fmt.Sprintf("object evaluation: %s", err))
 	}
 
 	return openfeature.InterfaceResolutionDetail{
@@ -393,7 +393,7 @@ func (p *Provider) Init(evaluationContext openfeature.EvaluationContext) error {
 func (p *Provider) Shutdown() {
 	if p.closeOnShutdown {
 		if err := p.client.Close(); err != nil {
-			p.l.Error("error during LaunchDarkly client shutdown: %s", err)
+			p.l.Error(fmt.Sprintf("error during LaunchDarkly client shutdown: %s", err))
 		}
 	}
 }

--- a/providers/launchdarkly/pkg/provider.go
+++ b/providers/launchdarkly/pkg/provider.go
@@ -105,7 +105,7 @@ func (p *Provider) toMultiLDContext(evalCtx openfeature.FlattenedContext) (ldcon
 			continue
 		}
 
-		p.l.Debug(fmt.Sprintf("mapping %q context kind", key))
+		p.l.Debug("mapping context kind", "kind", key)
 		if innerCtx, ok := attrs.(map[string]any); ok {
 			ctx, err := p.mapContext(ldcontext.Kind(key), openfeature.FlattenedContext(innerCtx))
 			if err != nil {
@@ -113,7 +113,7 @@ func (p *Provider) toMultiLDContext(evalCtx openfeature.FlattenedContext) (ldcon
 			}
 			ldCtx.Add(ctx)
 		} else {
-			p.l.Warn(fmt.Sprintf("multi-context: unexpected type in top-level attribute: %s", key))
+			p.l.Warn("multi-context: unexpected type in top-level attribute", "key", key)
 		}
 	}
 
@@ -173,7 +173,7 @@ func (p *Provider) toLDContext(evalCtx openfeature.FlattenedContext) (ldcontext.
 	if ok && strings.Trim(k, " ") != "" {
 		kind = ldcontext.Kind(k)
 	} else {
-		p.l.Warn(fmt.Sprintf("no context kind set, setting %q by default", kind))
+		p.l.Warn("no context kind set, using default", "kind", kind)
 	}
 
 	if kind == ldcontext.MultiKind {
@@ -224,7 +224,7 @@ func (p *Provider) toResolutionError(errorKind ldreason.EvalErrorKind, reason st
 // toProviderResolutionDetail maps LaunchDarkly's flag resolution details to
 // OPen
 func (p *Provider) toProviderResolutionDetail(detail ldreason.EvaluationDetail) openfeature.ProviderResolutionDetail {
-	p.l.Debug(fmt.Sprintf("launchdarkly evaluation detail: %v", detail))
+	p.l.Debug("launchdarkly evaluation detail", "detail", detail)
 
 	ofDetail := openfeature.ProviderResolutionDetail{
 		Reason: p.toReason(detail.Reason.GetKind()),
@@ -288,7 +288,7 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flagKey string, defaul
 
 	value, detail, err := p.client.BoolVariationDetail(flagKey, ldCtx, defaultValue)
 	if err != nil {
-		p.l.Error(fmt.Sprintf("boolean evaluation: %s", err))
+		p.l.Error("boolean evaluation error", "error", err)
 	}
 
 	return openfeature.BoolResolutionDetail{
@@ -309,7 +309,7 @@ func (p *Provider) StringEvaluation(ctx context.Context, flagKey string, default
 
 	value, detail, err := p.client.StringVariationDetail(flagKey, ldCtx, defaultValue)
 	if err != nil {
-		p.l.Error(fmt.Sprintf("string evaluation: %s", err))
+		p.l.Error("string evaluation error", "error", err)
 	}
 
 	return openfeature.StringResolutionDetail{
@@ -330,7 +330,7 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flagKey string, defaultV
 
 	value, detail, err := p.client.Float64VariationDetail(flagKey, ldCtx, defaultValue)
 	if err != nil {
-		p.l.Error(fmt.Sprintf("float evaluation: %s", err))
+		p.l.Error("float evaluation error", "error", err)
 	}
 
 	return openfeature.FloatResolutionDetail{
@@ -351,7 +351,7 @@ func (p *Provider) IntEvaluation(ctx context.Context, flagKey string, defaultVal
 
 	value, detail, err := p.client.IntVariationDetail(flagKey, ldCtx, int(defaultValue))
 	if err != nil {
-		p.l.Error(fmt.Sprintf("int evaluation: %s", err))
+		p.l.Error("int evaluation error", "error", err)
 	}
 
 	return openfeature.IntResolutionDetail{
@@ -372,7 +372,7 @@ func (p *Provider) ObjectEvaluation(ctx context.Context, flagKey string, default
 
 	value, detail, err := p.client.JSONVariationDetail(flagKey, ldCtx, ldvalue.CopyArbitraryValue(defaultValue))
 	if err != nil {
-		p.l.Error(fmt.Sprintf("object evaluation: %s", err))
+		p.l.Error("object evaluation error", "error", err)
 	}
 
 	return openfeature.InterfaceResolutionDetail{
@@ -393,7 +393,7 @@ func (p *Provider) Init(evaluationContext openfeature.EvaluationContext) error {
 func (p *Provider) Shutdown() {
 	if p.closeOnShutdown {
 		if err := p.client.Close(); err != nil {
-			p.l.Error(fmt.Sprintf("error during LaunchDarkly client shutdown: %s", err))
+			p.l.Error("error during LaunchDarkly client shutdown", "error", err)
 		}
 	}
 }

--- a/providers/launchdarkly/pkg/provider_test.go
+++ b/providers/launchdarkly/pkg/provider_test.go
@@ -37,6 +37,21 @@ func (l *testLogger) Warn(msg string, args ...any) {
 	l.t.Logf(msg, args...)
 }
 
+type loggedCall struct {
+	msg  string
+	args []any
+}
+
+type spyLogger struct {
+	warnCalls []loggedCall
+}
+
+func (l *spyLogger) Debug(msg string, args ...any) {}
+func (l *spyLogger) Error(msg string, args ...any) {}
+func (l *spyLogger) Warn(msg string, args ...any) {
+	l.warnCalls = append(l.warnCalls, loggedCall{msg: msg, args: args})
+}
+
 func makeLDClient(t *testing.T, flagsFilePath string) *ld.LDClient {
 	var config ld.Config
 	config.DataSource = ldfiledata.DataSource().FilePaths(flagsFilePath)
@@ -279,6 +294,21 @@ func TestContextCancellation(t *testing.T) {
 	cancel()
 	_, err = client.ObjectValue(ctx, "rate_limit_config", nil, evalCtx)
 	assert.Equals(t, errors.New("GENERAL: context canceled"), errors.Unwrap(err))
+}
+
+func TestLoggerFormat(t *testing.T) {
+	spy := &spyLogger{}
+	p := &Provider{options: options{kindAttr: "kind", l: spy}}
+
+	_, err := p.toMultiLDContext(openfeature.FlattenedContext{
+		"kind":         "multi",
+		"organization": "not-a-map",
+	})
+
+	assert.Ok(t, err)
+	assert.Equals(t, 1, len(spy.warnCalls))
+	assert.Equals(t, "multi-context: unexpected type in top-level attribute: organization", spy.warnCalls[0].msg)
+	assert.Equals(t, 0, len(spy.warnCalls[0].args))
 }
 
 // mockLDClient can be a struct that implements the LDClient interface for testing.

--- a/providers/launchdarkly/pkg/provider_test.go
+++ b/providers/launchdarkly/pkg/provider_test.go
@@ -3,6 +3,7 @@ package launchdarkly
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -16,25 +17,25 @@ import (
 )
 
 type testLogger struct {
-	t *testing.T
+	l *slog.Logger
 }
 
 func newTestLogger(t *testing.T) Logger {
 	return &testLogger{
-		t: t,
+		l: slog.New(slog.NewTextHandler(t.Output(), nil)),
 	}
 }
 
 func (l *testLogger) Debug(msg string, args ...any) {
-	l.t.Logf(msg, args...)
+	l.l.Debug(msg, args...)
 }
 
 func (l *testLogger) Error(msg string, args ...any) {
-	l.t.Logf(msg, args...)
+	l.l.Error(msg, args...)
 }
 
 func (l *testLogger) Warn(msg string, args ...any) {
-	l.t.Logf(msg, args...)
+	l.l.Warn(msg, args...)
 }
 
 type loggedCall struct {

--- a/providers/launchdarkly/pkg/provider_test.go
+++ b/providers/launchdarkly/pkg/provider_test.go
@@ -307,8 +307,9 @@ func TestLoggerFormat(t *testing.T) {
 
 	assert.Ok(t, err)
 	assert.Equals(t, 1, len(spy.warnCalls))
-	assert.Equals(t, "multi-context: unexpected type in top-level attribute: organization", spy.warnCalls[0].msg)
-	assert.Equals(t, 0, len(spy.warnCalls[0].args))
+	assert.Equals(t, "multi-context: unexpected type in top-level attribute", spy.warnCalls[0].msg)
+	assert.Equals(t, 2, len(spy.warnCalls[0].args))
+	assert.Equals(t, "organization", spy.warnCalls[0].args[1])
 }
 
 // mockLDClient can be a struct that implements the LDClient interface for testing.


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
The Logger interface (Debug/Warn/Error(msg string, args ...any)) doesn't do Sprintf-style interpolation. Every call in the LaunchDarkly provider package was written as if calling a Printf-style logger, embedding %s/%q/%v verbs directly in msg and passing the substitution value as a trailing arg instead of formatting in advance like in other providers. That behavior left the literal verb in the logged message text and turned the dangling positional argument into a malformed attribute, instead of producing the intended message.

 - Replace fmt.Sprintf-formatted messages with slog-style key-value attributes so structured loggers can parse fields instead of a single opaque string..

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

None

### Notes
<!-- any additional notes for this PR -->
None

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
None

### How to test
<!-- if applicable, add testing instructions under this section -->
 - Automatic: Added unit test.
 - Manual: Initialize LaunchDarkly client and connect to slog Logger to stdout. Check output doesn't contain `%s` format characters in the output.

