### PR TITLE
fix(launchdarkly): skip the reserved targetingKey attribute in multi-contexts

### DIFF
--- a/providers/launchdarkly/pkg/provider.go
+++ b/providers/launchdarkly/pkg/provider.go
@@ -98,10 +98,15 @@ func (p *Provider) Metadata() openfeature.Metadata {
 func (p *Provider) toMultiLDContext(evalCtx openfeature.FlattenedContext) (ldcontext.Context, error) {
 	ldCtx := ldcontext.NewMultiBuilder()
 
+	// attributes that are not context kinds: the kind attribute is implicit with
+	// multi-contexts, and the targeting key is always merged into the flattened
+	// context by the OpenFeature SDK even though it has no meaning at the
+	// multi-context top level (each kind's own key lives inside its sub-context).
+	skipList := []string{p.kindAttr, openfeature.TargetingKey}
+
 	// each top level attribute is a kind, and must have a map or struct as value
 	for key, attrs := range evalCtx {
-		// skip the kind attribute since it is implicit with multi-contexts
-		if key == p.kindAttr {
+		if slices.Contains(skipList, key) {
 			continue
 		}
 

--- a/providers/launchdarkly/pkg/provider_test.go
+++ b/providers/launchdarkly/pkg/provider_test.go
@@ -313,6 +313,35 @@ func TestLoggerFormat(t *testing.T) {
 	assert.Equals(t, "organization", spy.warnCalls[0].args[1])
 }
 
+func TestToMultiLDContext(t *testing.T) {
+	t.Run("does not warn about the reserved targeting key attribute", func(t *testing.T) {
+		spy := &spyLogger{}
+		p := &Provider{options: options{kindAttr: "kind", l: spy}}
+
+		_, err := p.toMultiLDContext(openfeature.FlattenedContext{
+			"kind":                   "multi",
+			openfeature.TargetingKey: "user-123",
+			"organization":           map[string]any{"key": "org-1"},
+		})
+
+		assert.Ok(t, err)
+		assert.Equals(t, 0, len(spy.warnCalls))
+	})
+
+	t.Run("still warns about a genuinely malformed top-level attribute", func(t *testing.T) {
+		spy := &spyLogger{}
+		p := &Provider{options: options{kindAttr: "kind", l: spy}}
+
+		_, err := p.toMultiLDContext(openfeature.FlattenedContext{
+			"kind":         "multi",
+			"organization": "not-a-map",
+		})
+
+		assert.Ok(t, err)
+		assert.Equals(t, 1, len(spy.warnCalls))
+	})
+}
+
 // mockLDClient can be a struct that implements the LDClient interface for testing.
 type mockLDClient struct {
 	ld.LDClient // Embedding the real client can be useful for mocking only specific methods


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
toMultiLDContext only skipped the kind attribute when iterating a flattened context's top-level attributes, treating every other key as a context kind that must map to an object. The OpenFeature SDK's flattenContext always merges the evaluation context's targeting key into that same top-level map as a plain string whenever it is set, so any multi-context evaluation with a non-empty targeting key logged a spurious "multi-context: unexpected type in top-level attribute" warning, even though the resulting LaunchDarkly context was built correctly. mapContext already carries an explicit skip list for this same reserved attribute when handling single-kind contexts; extend toMultiLDContext with an equivalent skip list so both code paths treat the reserved targeting key consistently.

- Fixed warning on valid calls with multi-context.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->
None

### Notes
<!-- any additional notes for this PR -->
None

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
None

### How to test
<!-- if applicable, add testing instructions under this section -->
Automatic: Added unit test.
Manual: Initialize LaunchDarkly client and connect to Logger to stdout. Check no warnings are printed when resolving a flag with multi-context.