### PR TITLE
fix(tests/flagd): check the envoy service lookup before using it

### DIFF
--- a/tests/flagd/testframework/testcontainer.go
+++ b/tests/flagd/testframework/testcontainer.go
@@ -94,6 +94,10 @@ func NewFlagdContainer(ctx context.Context, config FlagdContainerConfig) (*Flagd
 		return nil, err
 	}
 	envoy, err := composeStack.ServiceContainer(ctx, "envoy")
+	if err != nil {
+		composeStack.Down(ctx)
+		return nil, fmt.Errorf("failed to get the envoy service container: %w", err)
+	}
 	envoyPort, err := getMappedPort(ctx, composeStack, envoy, "9211")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The error from `composeStack.ServiceContainer(ctx, "envoy")` was overwritten by the next statement, so a compose stack with no envoy service fell through into `getMappedPort` holding an unusable container — surfacing as a confusing port-lookup failure instead of the real cause. Every other lookup in the function was already checked; this one was missed.

Not caught by lint: `ineffassign` and `errcheck` are both enabled, but golangci-lint reports `0 issues.` here, and standalone the package fails typecheck (it resolves `providers/flagd` from the module cache) so the analysis linters don't run on it at all.

### Teardown on a context of its own

Follow-up from review. Every setup failure path handed its own `ctx` to `ComposeStack.Down` — the context whose cancellation or deadline may well be why setup failed, and `Down` forwards it straight to Compose. So the cleanup that matters most was the one most likely to be skipped, leaving the stack running; the teardown error was discarded as well.

`downStack` gives cleanup a bounded context derived from `Background`, and joins its error onto the failure being returned. Applied to all three setup paths rather than just the envoy one. The two teardown methods on the container already used `context.Background()` for the same reason.

Also: the flagd lookup reported "failed to start compose stack", copied from the `Up()` call above it.

No behaviour change when the compose file does have an envoy service, which the testbed's does — the RPC e2e suite passes unchanged.